### PR TITLE
epic: Backend API & Config

### DIFF
--- a/.council/fix-manifest.md
+++ b/.council/fix-manifest.md
@@ -1,0 +1,67 @@
+# Fix Manifest — PR #27: epic: Backend API & Config
+
+Council verdict: CONDITIONAL | 2026-04-08 | 6 findings (6 verified)
+
+## Fixes Required
+
+### 1. smallint/integer type decode bug — silent data loss
+- **File**: `src/db/postgres.rs`
+- **Lines**: 305-312 (pg_value_to_json), also `src/api/mod.rs:319-327` (pg_value_to_csv_string)
+- **Type**: bug
+- **Severity**: critical
+- **Verification**: verified by Critic 2
+- **Fix**: Use `try_get::<i32>` for integer, `try_get::<i16>` for smallint, `try_get::<i64>` for bigint. Also fix `numeric` → use `sqlx::types::BigDecimal` or `String` instead of `f64`.
+- **Citations**: `src/db/postgres.rs:306-310`, `src/api/mod.rs:320-322`
+
+### 2. Unbounded page_size — DoS vector
+- **File**: `src/api/mod.rs`
+- **Line**: 139-151
+- **Type**: hardening
+- **Severity**: high
+- **Verification**: verified by Critic 1, Critic 2, Questioner
+- **Fix**: Clamp `page_size` to a maximum (e.g. 1000) after deserialization. Also guard `page_size=0`.
+- **Citations**: `src/api/mod.rs:139`, `src/db/postgres.rs:221`
+
+### 3. TOML injection in save_config
+- **File**: `src/api/setup.rs`
+- **Lines**: 113-128
+- **Type**: security
+- **Severity**: high
+- **Verification**: verified by Critic 1, Critic 2, Questioner
+- **Fix**: Build a typed struct and use `toml::to_string_pretty` instead of `format!` interpolation.
+- **Citations**: `src/api/setup.rs:113-128`
+
+### 4. Error messages leak DB internals
+- **File**: `src/api/mod.rs`
+- **Lines**: 364-375
+- **Type**: security
+- **Severity**: high
+- **Verification**: verified by Critic 1
+- **Fix**: Return generic "Internal server error" for 500s. Log the real error via `tracing::error!`. Also sanitize `test_connection` errors in `src/api/setup.rs:49-53`.
+- **Citations**: `src/api/mod.rs:371-374`, `src/api/setup.rs:49-53`
+
+### 5. sort_column not schema-validated
+- **File**: `src/db/postgres.rs`
+- **Lines**: 171-180
+- **Type**: bug
+- **Severity**: medium
+- **Verification**: verified by Critic 1, Critic 2, Questioner
+- **Fix**: Validate `sort_column` against `valid_column_names` set (same pattern as filter validation at lines 122-133).
+- **Citations**: `src/db/postgres.rs:171-180`
+
+### 6. Config parse error silently enters setup mode
+- **File**: `src/main.rs`
+- **Lines**: 26-29
+- **Type**: bug
+- **Severity**: medium
+- **Verification**: verified by Critic 2
+- **Fix**: Distinguish file-not-found from parse error. Only enter setup mode when no config file exists. Print the parse error and exit on malformed config.
+- **Citations**: `src/main.rs:26-29`, `src/config.rs:172-196`
+
+## Test Command
+```
+cargo test && cargo clippy
+```
+
+## Raw Data
+council-result: .council/fix-manifest.md

--- a/.council/fix-manifest.md
+++ b/.council/fix-manifest.md
@@ -1,67 +1,39 @@
-# Fix Manifest — PR #27: epic: Backend API & Config
+# Fix Manifest -- PR #27: epic: Backend API & Config
 
-Council verdict: CONDITIONAL | 2026-04-08 | 6 findings (6 verified)
+Council verdict: CONDITIONAL | 2026-04-08 | 2 findings (2 verified)
+
+Previous council (pre-hardening) had 6 findings -- all 6 were fixed in commit 6e26117.
+This council reviews the post-hardening state.
 
 ## Fixes Required
 
-### 1. smallint/integer type decode bug — silent data loss
-- **File**: `src/db/postgres.rs`
-- **Lines**: 305-312 (pg_value_to_json), also `src/api/mod.rs:319-327` (pg_value_to_csv_string)
-- **Type**: bug
-- **Severity**: critical
-- **Verification**: verified by Critic 2
-- **Fix**: Use `try_get::<i32>` for integer, `try_get::<i16>` for smallint, `try_get::<i64>` for bigint. Also fix `numeric` → use `sqlx::types::BigDecimal` or `String` instead of `f64`.
-- **Citations**: `src/db/postgres.rs:306-310`, `src/api/mod.rs:320-322`
-
-### 2. Unbounded page_size — DoS vector
-- **File**: `src/api/mod.rs`
-- **Line**: 139-151
-- **Type**: hardening
-- **Severity**: high
-- **Verification**: verified by Critic 1, Critic 2, Questioner
-- **Fix**: Clamp `page_size` to a maximum (e.g. 1000) after deserialization. Also guard `page_size=0`.
-- **Citations**: `src/api/mod.rs:139`, `src/db/postgres.rs:221`
-
-### 3. TOML injection in save_config
+### 1. save_config must verify connection before writing
 - **File**: `src/api/setup.rs`
-- **Lines**: 113-128
-- **Type**: security
-- **Severity**: high
-- **Verification**: verified by Critic 1, Critic 2, Questioner
-- **Fix**: Build a typed struct and use `toml::to_string_pretty` instead of `format!` interpolation.
-- **Citations**: `src/api/setup.rs:113-128`
-
-### 4. Error messages leak DB internals
-- **File**: `src/api/mod.rs`
-- **Lines**: 364-375
-- **Type**: security
-- **Severity**: high
-- **Verification**: verified by Critic 1
-- **Fix**: Return generic "Internal server error" for 500s. Log the real error via `tracing::error!`. Also sanitize `test_connection` errors in `src/api/setup.rs:49-53`.
-- **Citations**: `src/api/mod.rs:371-374`, `src/api/setup.rs:49-53`
-
-### 5. sort_column not schema-validated
-- **File**: `src/db/postgres.rs`
-- **Lines**: 171-180
+- **Lines**: 107-172
 - **Type**: bug
 - **Severity**: medium
-- **Verification**: verified by Critic 1, Critic 2, Questioner
-- **Fix**: Validate `sort_column` against `valid_column_names` set (same pattern as filter validation at lines 122-133).
-- **Citations**: `src/db/postgres.rs:171-180`
+- **Verification**: verified by Critic rebuttal, Questioner Q1+Q11
+- **Fix**: Call `postgres::test_connection(&req.database.url)` before writing seeki.toml. If the connection fails, return `{ success: false, error: "..." }` without writing the file. This reuses the existing `test_connection` function already in `src/db/postgres.rs:11-28`.
+- **Citations**: `src/api/setup.rs:107-172`, `src/main.rs:93`, `src/db/postgres.rs:11-28`
 
-### 6. Config parse error silently enters setup mode
-- **File**: `src/main.rs`
-- **Lines**: 26-29
+### 2. row_count_estimate exposes -1 for unanalyzed tables
+- **File**: `src/db/postgres.rs`, `src/db/mod.rs`
+- **Lines**: postgres.rs:50-53, mod.rs:24
 - **Type**: bug
 - **Severity**: medium
-- **Verification**: verified by Critic 2
-- **Fix**: Distinguish file-not-found from parse error. Only enter setup mode when no config file exists. Print the parse error and exit on malformed config.
-- **Citations**: `src/main.rs:26-29`, `src/config.rs:172-196`
+- **Verification**: verified by Questioner Q9, Critic rebuttal
+- **Fix**: Change `TableInfo.row_count_estimate` from `i64` to `Option<i64>`. In `list_tables`, clamp negative values to `None`. Update `api/mod.rs` serialization to emit `null` instead of `-1`.
+- **Citations**: `src/db/postgres.rs:50-53`, `src/db/mod.rs:24`, `src/api/mod.rs:107-109`
+
+## Informational Notes (not blocking)
+- SSRF via test_connection URL (mitigated by localhost bind)
+- Divergent pg_value_to_json / pg_value_to_csv_string implementations
+- ILIKE full-table scan at scale (acceptable for v0.1)
+- display_config queries DB on every request (cache for v0.2)
+- get_columns PK subquery missing table_schema filter
+- CSV error sentinel not RFC 4180 compliant (acceptable for v0.1)
 
 ## Test Command
 ```
-cargo test && cargo clippy
+cargo test
 ```
-
-## Raw Data
-council-result: .council/fix-manifest.md

--- a/.council/fix-manifest.md
+++ b/.council/fix-manifest.md
@@ -1,37 +1,37 @@
-# Fix Manifest -- PR #27: epic: Backend API & Config
+# Fix Manifest -- epic/1-backend-api-config merge into main
 
 Council verdict: CONDITIONAL | 2026-04-08 | 2 findings (2 verified)
 
-Previous council (pre-hardening) had 6 findings -- all 6 were fixed in commit 6e26117.
-This council reviews the post-hardening state.
+Third adversarial council (pre-merge review). Prior councils found 8 issues total -- all fixed.
+This council reviews the fully-hardened state before merging into main.
 
 ## Fixes Required
 
-### 1. save_config must verify connection before writing
-- **File**: `src/api/setup.rs`
-- **Lines**: 107-172
+### 1. u32 overflow in OFFSET computation
+- **File**: `src/db/postgres.rs`
+- **Line**: 287
 - **Type**: bug
-- **Severity**: medium
-- **Verification**: verified by Critic rebuttal, Questioner Q1+Q11
-- **Fix**: Call `postgres::test_connection(&req.database.url)` before writing seeki.toml. If the connection fails, return `{ success: false, error: "..." }` without writing the file. This reuses the existing `test_connection` function already in `src/db/postgres.rs:11-28`.
-- **Citations**: `src/api/setup.rs:107-172`, `src/main.rs:93`, `src/db/postgres.rs:11-28`
+- **Severity**: high
+- **Verification**: verified by Critic 2, conceded by Advocate
+- **Fix**: Cast `page` and `page_size` to `u64` before multiplication to prevent silent wrapping in release mode. e.g. `let offset = (params.page.saturating_sub(1) as u64) * (params.page_size as u64);` and interpolate as u64 into SQL.
+- **Citations**: `src/db/postgres.rs:287`, `src/db/mod.rs:48-49`
 
-### 2. row_count_estimate exposes -1 for unanalyzed tables
-- **File**: `src/db/postgres.rs`, `src/db/mod.rs`
-- **Lines**: postgres.rs:50-53, mod.rs:24
+### 2. CSV error sentinel is not valid CSV
+- **File**: `src/api/mod.rs`
+- **Lines**: 271-276, 322-327
 - **Type**: bug
 - **Severity**: medium
-- **Verification**: verified by Questioner Q9, Critic rebuttal
-- **Fix**: Change `TableInfo.row_count_estimate` from `i64` to `Option<i64>`. In `list_tables`, clamp negative values to `None`. Update `api/mod.rs` serialization to emit `null` instead of `-1`.
-- **Citations**: `src/db/postgres.rs:50-53`, `src/db/mod.rs:24`, `src/api/mod.rs:107-109`
+- **Verification**: verified by Critic 1 + Critic 2, conceded by Advocate
+- **Fix**: Either (a) remove the raw error text sentinels entirely and just close the stream (log the error server-side, which already happens), or (b) emit the error as a properly quoted CSV row. Option (a) is simpler and safer -- a truncated CSV is less harmful than a corrupted one.
+- **Citations**: `src/api/mod.rs:271-276`, `src/api/mod.rs:322-327`
 
 ## Informational Notes (not blocking)
-- SSRF via test_connection URL (mitigated by localhost bind)
-- Divergent pg_value_to_json / pg_value_to_csv_string implementations
-- ILIKE full-table scan at scale (acceptable for v0.1)
-- display_config queries DB on every request (cache for v0.2)
-- get_columns PK subquery missing table_schema filter
-- CSV error sentinel not RFC 4180 compliant (acceptable for v0.1)
+- CORS prefix match could be tightened to exact match (main.rs:47) -- low severity for localhost tool
+- No integration tests for DB layer (pre-existing gap, not introduced by this branch)
+- save_config accepts non-localhost hosts (low risk, setup mode is one-time)
+- Identifier validation rejects `$` in table/column names (compatibility edge case)
+- display_config / get_columns not cached (acceptable for v0.1, cache for v0.2)
+- Divergent pg_value_to_json / pg_value_to_csv_string boolean rendering (intentional: true/false vs Yes/No)
 
 ## Test Command
 ```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1455,6 +1455,7 @@ dependencies = [
  "axum",
  "clap",
  "dirs-next",
+ "http-body-util",
  "rand",
  "rust-embed",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,72 +18,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
-name = "anstream"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle"
-version = "1.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
-
-[[package]]
-name = "anstyle-parse"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
-dependencies = [
- "anstyle",
- "once_cell_polyfill",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
-
-[[package]]
-name = "argon2"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
-dependencies = [
- "base64ct",
- "blake2",
- "cpufeatures",
- "password-hash",
-]
 
 [[package]]
 name = "async-stream"
@@ -101,17 +39,6 @@ name = "async-stream-impl"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "async-trait"
-version = "0.1.89"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -225,15 +152,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "blake2"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
-dependencies = [
- "digest",
-]
-
-[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -271,52 +189,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "clap"
-version = "4.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
-dependencies = [
- "clap_builder",
- "clap_derive",
-]
-
-[[package]]
-name = "clap_builder"
-version = "4.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
-dependencies = [
- "anstream",
- "anstyle",
- "clap_lex",
- "strsim",
-]
-
-[[package]]
-name = "clap_derive"
-version = "4.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "clap_lex"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
-
-[[package]]
-name = "colorchoice"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
-
-[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -330,17 +202,6 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
-name = "cookie"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
-dependencies = [
- "percent-encoding",
- "time",
- "version_check",
-]
 
 [[package]]
 name = "cpufeatures"
@@ -421,16 +282,6 @@ dependencies = [
  "const-oid",
  "pem-rfc7468",
  "zeroize",
-]
-
-[[package]]
-name = "deranged"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "powerfmt",
- "serde_core",
 ]
 
 [[package]]
@@ -947,12 +798,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is_terminal_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -997,7 +842,6 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
- "cc",
  "pkg-config",
  "vcpkg",
 ]
@@ -1015,7 +859,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
  "scopeguard",
- "serde",
 ]
 
 [[package]]
@@ -1108,12 +951,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-conv"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
-
-[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1150,12 +987,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
-name = "once_cell_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1182,17 +1013,6 @@ dependencies = [
  "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
-]
-
-[[package]]
-name = "password-hash"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
-dependencies = [
- "base64ct",
- "rand_core",
- "subtle",
 ]
 
 [[package]]
@@ -1257,12 +1077,6 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
-
-[[package]]
-name = "powerfmt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1402,41 +1216,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rust-embed"
-version = "8.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
-dependencies = [
- "axum",
- "rust-embed-impl",
- "rust-embed-utils",
- "walkdir",
-]
-
-[[package]]
-name = "rust-embed-impl"
-version = "8.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
-dependencies = [
- "proc-macro2",
- "quote",
- "rust-embed-utils",
- "syn",
- "walkdir",
-]
-
-[[package]]
-name = "rust-embed-utils"
-version = "8.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
-dependencies = [
- "sha2",
- "walkdir",
-]
-
-[[package]]
 name = "rustls"
 version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1477,15 +1256,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1496,17 +1266,13 @@ name = "seeki"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "argon2",
  "async-stream",
  "axum",
  "bytes",
- "clap",
  "csv",
  "dirs-next",
  "futures",
  "http-body-util",
- "rand",
- "rust-embed",
  "serde",
  "serde_json",
  "sqlx",
@@ -1515,7 +1281,6 @@ dependencies = [
  "toml",
  "tower",
  "tower-http",
- "tower-sessions",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1904,12 +1669,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "strsim"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1990,37 +1749,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "time"
-version = "0.3.47"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
-dependencies = [
- "deranged",
- "itoa",
- "num-conv",
- "powerfmt",
- "serde_core",
- "time-core",
- "time-macros",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
-
-[[package]]
-name = "time-macros"
-version = "0.2.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
-dependencies = [
- "num-conv",
- "time-core",
 ]
 
 [[package]]
@@ -2158,22 +1886,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tower-cookies"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "151b5a3e3c45df17466454bb74e9ecedecc955269bdedbf4d150dfa393b55a36"
-dependencies = [
- "axum-core",
- "cookie",
- "futures-util",
- "http",
- "parking_lot",
- "pin-project-lite",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
 name = "tower-http"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2210,57 +1922,6 @@ name = "tower-service"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
-
-[[package]]
-name = "tower-sessions"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a05911f23e8fae446005fe9b7b97e66d95b6db589dc1c4d59f6a2d4d4927d3"
-dependencies = [
- "async-trait",
- "http",
- "time",
- "tokio",
- "tower-cookies",
- "tower-layer",
- "tower-service",
- "tower-sessions-core",
- "tower-sessions-memory-store",
- "tracing",
-]
-
-[[package]]
-name = "tower-sessions-core"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce8cce604865576b7751b7a6bc3058f754569a60d689328bb74c52b1d87e355b"
-dependencies = [
- "async-trait",
- "axum-core",
- "base64",
- "futures",
- "http",
- "parking_lot",
- "rand",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "time",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "tower-sessions-memory-store"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb05909f2e1420135a831dd5df9f5596d69196d0a64c3499ca474c4bd3d33242"
-dependencies = [
- "async-trait",
- "time",
- "tokio",
- "tower-sessions-core",
-]
 
 [[package]]
 name = "tracing"
@@ -2388,12 +2049,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
-name = "utf8parse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2410,16 +2065,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "walkdir"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
-dependencies = [
- "same-file",
- "winapi-util",
-]
 
 [[package]]
 name = "wasi"
@@ -2476,15 +2121,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
-dependencies = [
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -370,6 +392,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -527,6 +570,7 @@ checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -606,6 +650,7 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -1452,9 +1497,13 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "argon2",
+ "async-stream",
  "axum",
+ "bytes",
  "clap",
+ "csv",
  "dirs-next",
+ "futures",
  "http-body-util",
  "rand",
  "rust-embed",
@@ -1462,6 +1511,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "tokio",
+ "tokio-stream",
  "toml",
  "tower",
  "tower-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,6 @@ clap = { version = "4", features = ["derive"] }
 # Utilities
 anyhow = "1"
 dirs-next = "2"
+
+[dev-dependencies]
+http-body-util = "0.1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ tower = "0.5"
 tower-http = { version = "0.6", features = ["fs", "cors"] }
 
 # Database drivers
-sqlx = { version = "0.8", features = ["runtime-tokio", "tls-rustls", "postgres", "sqlite"] }
+sqlx = { version = "0.8", features = ["runtime-tokio", "tls-rustls", "postgres"] }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }
@@ -23,20 +23,9 @@ serde_json = "1"
 # Config
 toml = "0.8"
 
-# Auth
-argon2 = "0.5"
-rand = "0.8"
-tower-sessions = "0.14"
-
 # Logging
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-
-# Embed frontend assets
-rust-embed = { version = "8", features = ["axum"] }
-
-# CLI
-clap = { version = "4", features = ["derive"] }
 
 # CSV export
 csv = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,15 @@ rust-embed = { version = "8", features = ["axum"] }
 # CLI
 clap = { version = "4", features = ["derive"] }
 
+# CSV export
+csv = "1"
+
+# Async streaming
+futures = "0.3"
+async-stream = "0.3"
+tokio-stream = "0.1"
+bytes = "1"
+
 # Utilities
 anyhow = "1"
 dirs-next = "2"

--- a/backend-api-config-spec.md
+++ b/backend-api-config-spec.md
@@ -1,0 +1,306 @@
+# Feature: Backend API & Config
+
+## Overview
+
+**User Story**: As a non-technical team member (simulation analyst, data analyst, or engineer), I want SeeKi's backend to support configurable table exposure, display name overrides, per-column filtering, CSV export, and a first-run setup wizard so that the frontend can deliver a complete spreadsheet-like browsing experience without any SQL knowledge.
+
+**Problem**: The current backend scaffold provides only basic table listing, column metadata, and paginated row fetching. It lacks the configuration, filtering, export, and setup capabilities required by the MVP spec.
+
+**Out of Scope**:
+- Frontend implementation (covered by Epics 2-5)
+- Authentication/authorization (deferred -- MVP targets trusted internal network)
+- SQLite or MySQL support (PostgreSQL only for MVP)
+- Write operations (SeeKi is read-only by design)
+- Real-time data streaming / live updates
+- Saved views or bookmarks
+
+---
+
+## Success Condition
+
+> This feature is complete when all six API contracts (config display, per-column filters, CSV export, setup test-connection, setup save, table filtering) are implemented, return correct JSON/CSV shapes, maintain SQL injection prevention, and the server boots in setup-only mode when no config file exists.
+
+---
+
+## Open Questions
+
+| # | Question | Raised By | Resolved |
+|:--|:---------|:----------|:---------|
+| 1 | Column name auto-heuristic edge cases (e.g. `posn_lat` -> what?) -- tune during implementation | Brainstorm | [ ] |
+
+---
+
+## Scope
+
+### Must-Have
+
+- **Config extensions** (#7/T1): Add `[tables]`, `[display.columns]`, and `[branding]` sections to `AppConfig`. All sections optional with `#[serde(default)]`. `TablesConfig` has `include: Option<Vec<String>>` and `exclude: Option<Vec<String>>` -- both allowed simultaneously (include first, then subtract exclude). Update `seeki.toml.example`. Acceptance: missing sections parse without error; both include+exclude coexist correctly; config round-trips.
+
+- **Per-column filter support** (#8/T2): Accept `filter.{column_name}=value` query params on `GET /api/tables/{table}/rows`. Parse via `HashMap<String, String>` extraction with `filter.` prefix. Validate column names against table schema. Generate parameterized `WHERE col ILIKE $N` clauses combined with AND. Acceptance: single filter returns matching rows; multiple filters AND together; invalid column names return 400; filter values are parameterized (no SQL injection).
+
+- **Display config endpoint** (#9/T3): Add `GET /api/config/display` returning column display name overrides, branding info. Standalone `display_name(table, column, config)` utility function in `config.rs` -- DB layer untouched. Heuristic: snake_case to Title Case, drop `_id` suffix. Config overrides take precedence. Acceptance: endpoint returns correct JSON shape; `supervisor_id` casualifies to "Supervisor"; config override `"vehicles_log.posn_lat" = "Latitude"` takes precedence.
+
+- **CSV export endpoint** (#10/T4): Add `GET /api/export/{table}/csv` accepting same filter/sort params as the rows endpoint. Use SQLx cursor stream (`fetch()`) mapped to CSV row bytes via `csv` crate, streamed through `Body::from_stream`. Display names as CSV headers. `Content-Disposition: attachment; filename="{table}.csv"`. Acceptance: downloads valid CSV with display name headers; respects active filters and sort; streams 500K+ rows without OOM.
+
+- **Setup wizard backend endpoints** (#11/T5): Two-mode server architecture. `main()` checks for config file: no config boots setup-only server (`/api/setup/*` + static assets); config exists boots normal server. `POST /api/setup/test-connection` accepts `{ url }`, returns `{ success, error?, tables? }`. `POST /api/setup/save` accepts config payload, writes template-based `seeki.toml` to CWD with human-readable comments. Frontend shows "Configuration saved -- please refresh." Acceptance: valid connection returns success + table list; invalid connection returns descriptive error; save writes parseable `seeki.toml`; setup-only server boots when no config; normal server boots when config exists.
+
+- **Table include/exclude filtering** (#12/T6): Filter `list_tables` result through `TablesConfig`. Logic: start with all tables from DB, if `include` is set keep only those, if `exclude` is set remove those. Add `display_name` field derivation at API layer (not in DB layer). Acceptance: include-only shows listed tables; exclude-only hides listed; both together applies include then exclude.
+
+- **Error handling** (cross-cutting): Replace `AppError` with `thiserror`-based enum: `BadRequest(String)` -> 400, `NotFound(String)` -> 404, `Internal(anyhow::Error)` -> 500. Existing `From<anyhow::Error>` preserved. Acceptance: bad requests return 400; not-found returns 404; internal errors return 500 with no sensitive details leaked.
+
+### Should-Have
+
+- Pagination controls metadata in row query response (total pages, has_next, has_prev)
+
+### Nice-to-Have
+
+- Typed filter operators (>, <, between, before/after) beyond ILIKE -- first post-MVP feature
+- Connection pool health check endpoint
+
+---
+
+## Technical Plan
+
+**Affected Components**:
+
+| Layer | Files | Changes |
+|:------|:------|:--------|
+| Config | `src/config.rs` | Add `TablesConfig`, `DisplayConfig`, `BrandingConfig` structs; add `display_name()` utility function |
+| API | `src/api/mod.rs` | Add routes for display config, CSV export, setup endpoints; refine `AppError` with `thiserror`; add per-column filter parsing via HashMap |
+| DB | `src/db/mod.rs` | Add `test_connection()` to `DatabasePool`; add `stream_rows()` method for cursor-based streaming |
+| DB/PG | `src/db/postgres.rs` | Implement `test_connection()`; add per-column filter support to `query_rows`; add `stream_rows()` for CSV export |
+| Main | `src/main.rs` | Two-mode server branch: detect config presence, boot setup-only or normal server |
+| Example | `seeki.toml.example` | Add all new config sections with inline documentation |
+| Deps | `Cargo.toml` | Add `csv`, `thiserror` crates |
+
+**Data Model Changes**: None -- SeeKi is read-only and introspects existing schemas.
+
+**API Contracts**:
+
+| Method | Path | Description | Request | Response |
+|:-------|:-----|:------------|:--------|:---------|
+| `GET` | `/api/tables` | List exposed tables (filtered by config) | -- | `{ tables: [{ name, row_count_estimate }] }` |
+| `GET` | `/api/tables/{table}/columns` | Column metadata | -- | `{ columns: [{ name, data_type, display_type, is_nullable, is_primary_key }] }` |
+| `GET` | `/api/tables/{table}/rows` | Paginated rows with filters | `?page&page_size&sort_column&sort_direction&search&filter.{col}=val` | `{ columns, rows, total_rows, page, page_size }` |
+| `GET` | `/api/export/{table}/csv` | Stream CSV export | Same query params as rows | `text/csv` attachment |
+| `GET` | `/api/config/display` | Display config for frontend | -- | `{ columns: { "table.col": "Name" }, branding: { title, subtitle } }` |
+| `POST` | `/api/setup/test-connection` | Test DB connection | `{ url: string }` | `{ success: bool, error?: string, tables?: string[] }` |
+| `POST` | `/api/setup/save` | Write config to disk | `{ database: {...}, tables: {...}, branding: {...} }` | `{ success: bool }` |
+
+**Dependencies**:
+- `csv` crate -- CSV streaming writer
+- `thiserror` crate -- typed error enum
+
+**Risks**:
+
+| Risk | Likelihood | Mitigation |
+|:-----|:-----------|:-----------|
+| SQLx cursor holds connection for entire CSV download | Low | SeeKi targets 1-2 concurrent users; pool of 5 connections is sufficient |
+| Column name heuristic produces bad guesses | Medium | Keep heuristic simple (snake_case -> Title Case, drop `_id`); config overrides are the escape hatch |
+| Setup wizard writes config while another process reads | Low | Setup runs only on first launch when no other instance exists |
+| HashMap query param extraction misses edge cases | Low | Validate extracted column names against schema before building SQL |
+
+---
+
+## Acceptance Scenarios
+
+```gherkin
+Feature: Backend API & Config
+  As a non-technical team member
+  I want SeeKi's backend to support configuration, filtering, export, and setup
+  So that the frontend can deliver a complete browsing experience
+
+  Background:
+    Given SeeKi is running with a valid seeki.toml pointing to a PostgreSQL database
+    And the database contains tables "vehicles", "vehicles_log" (427K rows), and "events"
+
+  Rule: Config extensions parse correctly
+
+    Scenario: Missing optional sections use defaults
+      Given seeki.toml contains only [server] and [database] sections
+      When the application starts
+      Then it boots successfully with default config (all tables exposed, no display overrides, no branding)
+
+    Scenario: Include and exclude coexist
+      Given seeki.toml contains [tables] include = ["vehicles", "vehicles_log", "events"] and exclude = ["events"]
+      When the application starts
+      Then the effective table list is ["vehicles", "vehicles_log"]
+
+  Rule: Per-column filter support
+
+    Scenario: Single column filter
+      Given the user sends GET /api/tables/vehicles_log/rows?filter.vehicle_id=ADT3
+      When the server processes the request
+      Then only rows where vehicle_id contains "ADT3" are returned
+      And the response total_rows reflects the filtered count
+
+    Scenario: Multiple column filters combine with AND
+      Given the user sends GET /api/tables/vehicles_log/rows?filter.vehicle_id=ADT3&filter.supervisor=Local
+      When the server processes the request
+      Then only rows matching both filters are returned
+
+    Scenario: Invalid column name returns 400
+      Given the user sends GET /api/tables/vehicles_log/rows?filter.nonexistent_col=foo
+      When the server processes the request
+      Then the response status is 400
+      And the body contains an error message about invalid column name
+
+    Scenario: Filter values are parameterized
+      Given the user sends GET /api/tables/vehicles_log/rows?filter.vehicle_id='; DROP TABLE vehicles;--
+      When the server processes the request
+      Then the filter value is treated as a literal string parameter
+      And no SQL injection occurs
+
+  Rule: Display config endpoint
+
+    Scenario: Returns correct JSON shape
+      Given seeki.toml contains [display.columns] with "vehicles_log.posn_lat" = "Latitude"
+      And [branding] with title = "AutoConnect" and subtitle = "Fleet Telemetry"
+      When the user sends GET /api/config/display
+      Then the response contains columns with "vehicles_log.posn_lat" mapped to "Latitude"
+      And branding with title "AutoConnect" and subtitle "Fleet Telemetry"
+
+    Scenario: Auto-heuristic casualifies column names
+      Given no config override exists for "vehicles_log.supervisor_id"
+      When the user sends GET /api/config/display
+      Then "vehicles_log.supervisor_id" maps to "Supervisor"
+
+    Scenario: Config override takes precedence over heuristic
+      Given seeki.toml contains [display.columns] with "vehicles_log.supervisor_id" = "Team Lead"
+      When the user sends GET /api/config/display
+      Then "vehicles_log.supervisor_id" maps to "Team Lead" (not "Supervisor")
+
+  Rule: CSV export streams correctly
+
+    Scenario: Export with display name headers
+      Given the user sends GET /api/export/vehicles/csv
+      When the server processes the request
+      Then the response Content-Type is "text/csv"
+      And the Content-Disposition header contains 'attachment; filename="vehicles.csv"'
+      And the first row contains display names (e.g. "Vehicle" not "vehicle_id")
+
+    Scenario: Export respects filters and sort
+      Given the user sends GET /api/export/vehicles_log/csv?filter.vehicle_id=ADT3&sort_column=vehicle_id&sort_direction=asc
+      When the server streams the CSV
+      Then only rows matching the filter are included
+      And rows are sorted by vehicle_id ascending
+
+    Scenario: Large table export does not exhaust memory
+      Given vehicles_log has 427K rows
+      When the user sends GET /api/export/vehicles_log/csv
+      Then the full CSV streams to completion
+      And server memory usage remains bounded (cursor-based streaming)
+
+  Rule: Setup wizard backend
+
+    Scenario: Test valid connection
+      Given no seeki.toml exists and the setup-only server is running
+      When the user sends POST /api/setup/test-connection with a valid PostgreSQL URL
+      Then the response contains success: true and tables: ["vehicles", "vehicles_log", "events"]
+
+    Scenario: Test invalid connection
+      Given the setup-only server is running
+      When the user sends POST /api/setup/test-connection with an invalid URL
+      Then the response contains success: false and a descriptive error message
+
+    Scenario: Save writes valid config
+      Given the setup-only server is running
+      When the user sends POST /api/setup/save with a complete config payload
+      Then seeki.toml is written to CWD with correct values and human-readable comments
+      And the response contains success: true
+
+    Scenario: Setup-only mode when no config
+      Given no seeki.toml exists in CWD or ~/.config/seeki/
+      When the SeeKi binary starts
+      Then only /api/setup/* endpoints are available
+      And data endpoints return 404 or are not mounted
+
+    Scenario: Normal mode when config exists
+      Given a valid seeki.toml exists
+      When the SeeKi binary starts
+      Then all data endpoints are available
+      And /api/setup/* endpoints are not mounted
+
+  Rule: Table include/exclude filtering
+
+    Scenario: Include-only filtering
+      Given seeki.toml contains [tables] include = ["vehicles", "vehicles_log"]
+      When the user sends GET /api/tables
+      Then only "vehicles" and "vehicles_log" are returned
+      And "events" is not in the response
+
+    Scenario: Exclude-only filtering
+      Given seeki.toml contains [tables] exclude = ["events"]
+      When the user sends GET /api/tables
+      Then "vehicles" and "vehicles_log" are returned
+      And "events" is not in the response
+
+    Scenario: Both include and exclude
+      Given seeki.toml contains [tables] include = ["vehicles", "vehicles_log", "events"] and exclude = ["events"]
+      When the user sends GET /api/tables
+      Then only "vehicles" and "vehicles_log" are returned
+
+  Rule: Error handling returns appropriate status codes
+
+    Scenario: Bad request returns 400
+      Given the user sends a request with an invalid column name in a filter
+      When the server processes the request
+      Then the response status is 400
+      And the body contains a descriptive error message
+
+    Scenario: Table not found returns 404
+      Given the user sends GET /api/export/nonexistent_table/csv
+      When the server processes the request
+      Then the response status is 404
+
+    Scenario: Internal error returns 500 without sensitive details
+      Given the database connection drops unexpectedly
+      When the user sends any data request
+      Then the response status is 500
+      And the error message does not contain connection strings or credentials
+```
+
+---
+
+## Task Breakdown
+
+| ID | Task | Issue | Priority | Dependencies | Status |
+|:---|:-----|:------|:---------|:-------------|:-------|
+| T0 | **Cross-cutting: Error handling** -- Add `thiserror`, replace `AppError` with status-code-aware enum | -- | High | None | pending |
+| T1 | **Config extensions** -- Add `TablesConfig`, `DisplayConfig`, `BrandingConfig` to `AppConfig`; update `seeki.toml.example` | #7 | High | None | pending |
+| T2 | **Per-column filter support** -- Add `filter.{column}` param parsing and parameterized WHERE clauses | #8 | High | T0 | pending |
+| T3 | **Display config endpoint** -- Add `GET /api/config/display` with `display_name()` utility | #9 | High | T1 | pending |
+| T4 | **CSV export endpoint** -- Add `GET /api/export/{table}/csv` with cursor streaming | #10 | High | T0, T2, T3 | pending |
+| T5 | **Setup wizard endpoints** -- Two-mode server, `test-connection`, `save` endpoints | #11 | High | T1 | pending |
+| T6 | **Table include/exclude filtering** -- Filter `list_tables` by config; `display_name` at API layer | #12 | High | T1 | pending |
+
+**Dependency graph**: T0 and T1 are independent roots. T2 depends on T0. T3 and T5 and T6 depend on T1. T4 depends on T0, T2, and T3.
+
+**Suggested implementation order**: T0 -> T1 -> T2 + T3 + T5 + T6 (parallel) -> T4
+
+---
+
+## Exit Criteria
+
+- [ ] All Must-Have acceptance scenarios pass against a test PostgreSQL database
+- [ ] SQL injection prevention maintained: table/column names validated, filter values parameterized
+- [ ] Config changes are backward-compatible (missing sections use sensible defaults)
+- [ ] All API contracts return correct JSON/CSV shapes matching the spec
+- [ ] CSV export streams 500K+ rows without OOM
+- [ ] Two-mode server correctly detects config presence and boots appropriate routes
+- [ ] `cargo clippy` passes with no warnings
+- [ ] `cargo test` passes
+
+---
+
+## References
+
+- MVP spec: `seeki-mvp-spec.md` (tasks T1-T6)
+- Epic issue: #1
+- PR: #27 (`epic/1-backend-api-config`)
+- Sub-issues: #7 (config), #8 (filters), #9 (display), #10 (CSV), #11 (setup), #12 (table filtering)
+- Brainstorm: approved in this conversation session
+
+---
+
+*Authored by: Clault KiperS 4.6*

--- a/config-extensions-spec.md
+++ b/config-extensions-spec.md
@@ -1,0 +1,210 @@
+# Feature: Config Extensions
+
+## Overview
+
+**User Story**: As a SeeKi administrator, I want to configure which tables are exposed, how columns and tables are displayed, and set branding for the app so that the interface is tailored to my team's needs without code changes.
+
+**Problem**: The current `AppConfig` only supports `[server]` and `[database]` sections. There is no way to control which tables appear, override column/table display names, or set app branding -- all of which are required by downstream features (display config endpoint, setup wizard, table filtering).
+
+**Out of Scope**:
+- API routes (T3 display config endpoint)
+- Database query changes (T2 per-column filters, T6 table filtering logic)
+- Two-mode server (T5 setup wizard)
+- Error handling refactor (T0)
+
+---
+
+## Success Condition
+
+> This feature is complete when `AppConfig` parses `[tables]`, `[display]`, and `[branding]` sections from TOML with sensible defaults, two utility functions convert raw names to display names using config overrides and heuristics, and existing configs (with only `[server]` + `[database]`) continue to parse without error.
+
+---
+
+## Open Questions
+
+| # | Question | Raised By | Resolved |
+|:--|:---------|:----------|:---------|
+| 1 | Column name heuristic edge cases (e.g. `posn_lat` -> "Posn Lat" vs something better) -- tune during implementation | Brainstorm | [ ] |
+
+---
+
+## Scope
+
+### Must-Have
+
+- **TablesConfig struct**: `include: Option<Vec<String>>`, `exclude: Option<Vec<String>>`. Both allowed simultaneously -- include applied first, then exclude subtracted. `#[serde(default)]` on the `AppConfig` field. Acceptance: both fields parse correctly; missing section defaults to no filtering.
+
+- **DisplayConfig struct**: `tables: HashMap<String, String>` for table display name overrides, `columns: HashMap<String, HashMap<String, String>>` for column overrides (nested TOML: `[display.columns.table_name]`). `#[serde(default)]`. Acceptance: nested TOML structure parses into correct HashMap nesting; empty section defaults to empty maps.
+
+- **BrandingConfig struct**: `title: Option<String>`, `subtitle: Option<String>`. `#[serde(default)]`. Acceptance: missing section defaults to `None` for both fields.
+
+- **display_name_table() utility**: `fn display_name_table(table: &str, config: &DisplayConfig) -> String`. Check `config.tables` override first; if none, apply heuristic (snake_case to Title Case). Acceptance: `vehicles_log` -> "Vehicles Log" by default; config override takes precedence.
+
+- **display_name_column() utility**: `fn display_name_column(table: &str, column: &str, config: &DisplayConfig) -> String`. Check `config.columns[table][column]` override first; if none, apply heuristic (snake_case to Title Case, drop `_id` suffix). Acceptance: `supervisor_id` -> "Supervisor" by default; config override takes precedence.
+
+- **Updated seeki.toml.example**: Document all new sections with inline comments and example values. Acceptance: example file contains `[tables]`, `[display.tables]`, `[display.columns.example_table]`, and `[branding]` sections.
+
+- **Backward compatibility**: Existing configs with only `[server]` and `[database]` must continue to parse without error. Acceptance: minimal config loads successfully with all new fields at defaults.
+
+### Should-Have
+
+- None -- this is a focused foundational task.
+
+### Nice-to-Have
+
+- None.
+
+---
+
+## Technical Plan
+
+**Affected Components**:
+
+| File | Changes |
+|:-----|:--------|
+| `src/config.rs` | Add `TablesConfig`, `DisplayConfig`, `BrandingConfig` structs; add `tables`, `display`, `branding` fields to `AppConfig`; add `display_name_table()` and `display_name_column()` functions; add `casualify()` helper |
+| `seeki.toml.example` | Add all new config sections with documented examples |
+
+**Data Model Changes**: None -- config-only changes, no database interaction.
+
+**API Contracts**: None -- this task adds no routes.
+
+**Dependencies**: None -- uses only `serde`, `toml`, and `std::collections::HashMap` (all already in scope).
+
+**Risks**:
+
+| Risk | Likelihood | Mitigation |
+|:-----|:-----------|:-----------|
+| TOML nested table syntax confuses users editing config | Low | Clear comments in `seeki.toml.example`; setup wizard (T5) will generate the file |
+| Heuristic produces poor display names for unusual column names | Medium | Heuristic is intentionally simple; config overrides are the escape hatch |
+
+---
+
+## Acceptance Scenarios
+
+```gherkin
+Feature: Config Extensions
+  As a SeeKi administrator
+  I want to configure table exposure, display names, and branding
+  So that the interface is tailored to my team
+
+  Rule: Config backward compatibility
+
+    Scenario: Minimal config parses with defaults
+      Given a seeki.toml containing only [server] and [database] sections
+      When AppConfig::load() is called
+      Then the config loads successfully
+      And tables.include is None
+      And tables.exclude is None
+      And display.tables is an empty HashMap
+      And display.columns is an empty HashMap
+      And branding.title is None
+      And branding.subtitle is None
+
+    Scenario: Full config with all sections parses correctly
+      Given a seeki.toml containing all sections including [tables], [display], and [branding]
+      When AppConfig::load() is called
+      Then all fields are populated with the values from the file
+
+  Rule: Tables include and exclude
+
+    Scenario: Both include and exclude set
+      Given a TablesConfig with include = ["a", "b", "c"] and exclude = ["c"]
+      When the effective table list is computed
+      Then the result is ["a", "b"]
+
+    Scenario: Only include set
+      Given a TablesConfig with include = ["a", "b"] and exclude = None
+      When the effective table list is computed from tables ["a", "b", "c", "d"]
+      Then the result is ["a", "b"]
+
+    Scenario: Only exclude set
+      Given a TablesConfig with include = None and exclude = ["c"]
+      When the effective table list is computed from tables ["a", "b", "c", "d"]
+      Then the result is ["a", "b", "d"]
+
+    Scenario: Neither set
+      Given a TablesConfig with include = None and exclude = None
+      When the effective table list is computed from tables ["a", "b", "c"]
+      Then all tables are returned: ["a", "b", "c"]
+
+  Rule: Display name heuristic for columns
+
+    Scenario: Snake case to Title Case
+      Given no config override for "my_table.some_column"
+      When display_name_column("my_table", "some_column", &config) is called
+      Then it returns "Some Column"
+
+    Scenario: Drop _id suffix
+      Given no config override for "vehicles_log.supervisor_id"
+      When display_name_column("vehicles_log", "supervisor_id", &config) is called
+      Then it returns "Supervisor"
+
+    Scenario: Config override takes precedence for columns
+      Given config has display.columns.vehicles_log.posn_lat = "Latitude"
+      When display_name_column("vehicles_log", "posn_lat", &config) is called
+      Then it returns "Latitude"
+
+  Rule: Display name heuristic for tables
+
+    Scenario: Table snake case to Title Case
+      Given no config override for "vehicles_log"
+      When display_name_table("vehicles_log", &config) is called
+      Then it returns "Vehicles Log"
+
+    Scenario: Config override takes precedence for tables
+      Given config has display.tables.vehicles_log = "Fleet Log"
+      When display_name_table("vehicles_log", &config) is called
+      Then it returns "Fleet Log"
+
+  Rule: Branding defaults
+
+    Scenario: No branding section
+      Given a seeki.toml with no [branding] section
+      When AppConfig::load() is called
+      Then branding.title is None and branding.subtitle is None
+
+    Scenario: Custom branding
+      Given a seeki.toml with [branding] title = "AutoConnect" and subtitle = "Fleet Telemetry"
+      When AppConfig::load() is called
+      Then branding.title is Some("AutoConnect") and branding.subtitle is Some("Fleet Telemetry")
+```
+
+---
+
+## Task Breakdown
+
+| ID | Task | Priority | Dependencies | Status |
+|:---|:-----|:---------|:-------------|:-------|
+| T1.1 | Add `TablesConfig`, `DisplayConfig`, `BrandingConfig` structs to `config.rs` | High | None | pending |
+| T1.2 | Add new fields to `AppConfig` with `#[serde(default)]` | High | T1.1 | pending |
+| T1.3 | Implement `casualify()` helper (snake_case to Title Case, optional `_id` drop) | High | None | pending |
+| T1.4 | Implement `display_name_table()` and `display_name_column()` | High | T1.1, T1.3 | pending |
+| T1.5 | Update `seeki.toml.example` with all new sections | High | T1.1 | pending |
+| T1.6 | Write unit tests for config parsing and display name functions | High | T1.1-T1.4 | pending |
+
+---
+
+## Exit Criteria
+
+- [ ] `cargo test` passes with all new unit tests
+- [ ] `cargo clippy` clean with no warnings
+- [ ] Existing minimal config (only `[server]` + `[database]`) parses without error
+- [ ] Full config with all new sections parses correctly
+- [ ] `display_name_column` applies heuristic and respects overrides
+- [ ] `display_name_table` applies heuristic and respects overrides
+- [ ] `seeki.toml.example` documents all new sections with examples
+
+---
+
+## References
+
+- Epic spec: `backend-api-config-spec.md`
+- Epic issue: #1
+- This issue: #7
+- PR: #33 (`feature/7-config-extensions-tables-display-branding-sections`)
+- Parent epic PR: #27 (`epic/1-backend-api-config`)
+
+---
+
+*Authored by: Clault KiperS 4.6*

--- a/seeki.toml.example
+++ b/seeki.toml.example
@@ -6,3 +6,23 @@ port = 3141
 kind = "postgres"
 url = "postgres://user:password@localhost:5432/mydb"
 max_connections = 5
+
+# Optional table exposure controls. If `include` is set, only those tables are
+# shown. `exclude` is applied after `include`, so you can start broad and trim.
+[tables]
+include = ["vehicles_log", "drivers", "audit_log"]
+exclude = ["audit_log"]
+
+# Optional sidebar display name overrides for tables.
+[display.tables]
+vehicles_log = "Fleet Log"
+
+# Optional per-table column display name overrides.
+[display.columns.vehicles_log]
+posn_lat = "Latitude"
+supervisor_id = "Supervisor"
+
+# Optional app branding shown in the UI shell.
+[branding]
+title = "AutoConnect"
+subtitle = "Fleet Telemetry"

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::AppState;
 use crate::config::{display_name_column, display_name_table};
+use crate::db::{RowQueryParams, ValidationError};
 
 pub fn router() -> Router<Arc<AppState>> {
     Router::new()
@@ -145,24 +146,39 @@ fn default_page_size() -> u32 {
     50
 }
 
+/// Extract per-column filters from query params with the `filter.` prefix.
+/// e.g. `?filter.vehicle_id=ADT3&filter.supervisor=Local` → {"vehicle_id": "ADT3", "supervisor": "Local"}
+fn parse_filters(all_params: &HashMap<String, String>) -> HashMap<String, String> {
+    all_params
+        .iter()
+        .filter_map(|(k, v)| {
+            k.strip_prefix("filter.")
+                .map(|col| (col.to_string(), v.clone()))
+        })
+        .collect()
+}
+
 async fn get_rows(
     State(state): State<Arc<AppState>>,
     Path(table): Path<String>,
     Query(params): Query<RowsQuery>,
+    Query(all_params): Query<HashMap<String, String>>,
 ) -> Result<Json<serde_json::Value>, AppError> {
     if !state.config.tables.allows(&table) {
         return Err(AppError::not_found(format!("Table '{table}' not found")));
     }
+    let filters = parse_filters(&all_params);
     let result = state
         .db
-        .query_rows(
-            &table,
-            params.page,
-            params.page_size,
-            params.sort_column.as_deref(),
-            params.sort_direction.as_deref(),
-            params.search.as_deref(),
-        )
+        .query_rows(&RowQueryParams {
+            table: &table,
+            page: params.page,
+            page_size: params.page_size,
+            sort_column: params.sort_column.as_deref(),
+            sort_direction: params.sort_direction.as_deref(),
+            search: params.search.as_deref(),
+            filters: &filters,
+        })
         .await?;
     Ok(Json(serde_json::json!(result)))
 }
@@ -180,10 +196,21 @@ impl AppError {
             message: message.into(),
         }
     }
+
+    fn bad_request(message: impl Into<String>) -> Self {
+        Self {
+            status: axum::http::StatusCode::BAD_REQUEST,
+            message: message.into(),
+        }
+    }
 }
 
 impl From<anyhow::Error> for AppError {
     fn from(err: anyhow::Error) -> Self {
+        // Map ValidationError from the DB layer to HTTP 400
+        if let Some(ve) = err.downcast_ref::<ValidationError>() {
+            return Self::bad_request(ve.0.clone());
+        }
         Self {
             status: axum::http::StatusCode::INTERNAL_SERVER_ERROR,
             message: err.to_string(),
@@ -273,5 +300,60 @@ mod tests {
         assert_eq!(vl["display_name"], "Fleet Log");
         assert_eq!(vl["columns"]["posn_lat"]["display_name"], "Latitude");
         assert_eq!(vl["columns"]["supervisor_id"]["display_name"], "Supervisor");
+    }
+
+    #[test]
+    fn parse_filters_extracts_filter_prefixed_params() {
+        let mut params = HashMap::new();
+        params.insert("filter.vehicle_id".into(), "ADT3".into());
+        params.insert("filter.supervisor".into(), "Local".into());
+        params.insert("page".into(), "1".into());
+        params.insert("search".into(), "test".into());
+
+        let filters = parse_filters(&params);
+        assert_eq!(filters.len(), 2);
+        assert_eq!(filters["vehicle_id"], "ADT3");
+        assert_eq!(filters["supervisor"], "Local");
+    }
+
+    #[test]
+    fn parse_filters_returns_empty_when_no_filters() {
+        let mut params = HashMap::new();
+        params.insert("page".into(), "1".into());
+        params.insert("page_size".into(), "50".into());
+
+        let filters = parse_filters(&params);
+        assert!(filters.is_empty());
+    }
+
+    #[test]
+    fn parse_filters_handles_empty_params() {
+        let params = HashMap::new();
+        let filters = parse_filters(&params);
+        assert!(filters.is_empty());
+    }
+
+    #[test]
+    fn parse_filters_preserves_filter_value_exactly() {
+        let mut params = HashMap::new();
+        params.insert("filter.name".into(), "Hello World".into());
+
+        let filters = parse_filters(&params);
+        assert_eq!(filters["name"], "Hello World");
+    }
+
+    #[test]
+    fn validation_error_maps_to_bad_request() {
+        let err = anyhow::Error::from(ValidationError("bad column".into()));
+        let app_err = AppError::from(err);
+        assert_eq!(app_err.status, axum::http::StatusCode::BAD_REQUEST);
+        assert_eq!(app_err.message, "bad column");
+    }
+
+    #[test]
+    fn generic_error_maps_to_internal_server_error() {
+        let err = anyhow::anyhow!("something broke");
+        let app_err = AppError::from(err);
+        assert_eq!(app_err.status, axum::http::StatusCode::INTERNAL_SERVER_ERROR);
     }
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -58,10 +58,15 @@ async fn get_display_config(
         .filter(|t| state.config.tables.allows(&t.name))
         .collect();
 
+    let table_names: Vec<&str> = allowed_tables.iter().map(|t| t.name.as_str()).collect();
+    let all_columns = state.db.get_columns_bulk(&table_names).await?;
+
     let mut tables = HashMap::new();
     for table in &allowed_tables {
-        let columns_info = state.db.get_columns(&table.name).await?;
-        let columns: HashMap<String, ColumnDisplayConfig> = columns_info
+        let columns: HashMap<String, ColumnDisplayConfig> = all_columns
+            .get(&table.name)
+            .cloned()
+            .unwrap_or_default()
             .into_iter()
             .map(|c| {
                 let display = display_name_column(&table.name, &c.name, &state.config.display);
@@ -150,6 +155,8 @@ fn default_page_size() -> u32 {
     50
 }
 
+const MAX_PAGE_SIZE: u32 = 1000;
+
 /// Extract per-column filters from query params with the `filter.` prefix.
 /// e.g. `?filter.vehicle_id=ADT3&filter.supervisor=Local` → {"vehicle_id": "ADT3", "supervisor": "Local"}
 fn parse_filters(all_params: &HashMap<String, String>) -> HashMap<String, String> {
@@ -171,13 +178,15 @@ async fn get_rows(
     if !state.config.tables.allows(&table) {
         return Err(AppError::not_found(format!("Table '{table}' not found")));
     }
+    let page = params.page.max(1);
+    let page_size = params.page_size.clamp(1, MAX_PAGE_SIZE);
     let filters = parse_filters(&all_params);
     let result = state
         .db
         .query_rows(&RowQueryParams {
             table: &table,
-            page: params.page,
-            page_size: params.page_size,
+            page,
+            page_size,
             sort_column: params.sort_column.as_deref(),
             sort_direction: params.sort_direction.as_deref(),
             search: params.search.as_deref(),
@@ -256,11 +265,20 @@ async fn export_csv(
 
         let (_cols, mut row_stream) = match stream_result {
             Ok(v) => v,
-            Err(_) => return,
+            Err(e) => {
+                tracing::error!(error = %e, "CSV export: failed to open row stream");
+                let _ = tx
+                    .send(Ok(bytes::Bytes::from(
+                        "\n# ERROR: Export failed before streaming rows. The data above is incomplete.\n",
+                    )))
+                    .await;
+                return;
+            }
         };
 
         let mut batch_buf = Vec::with_capacity(8192);
         let mut batch_count = 0u32;
+        let mut stream_error = false;
 
         while let Some(row_result) = row_stream.next().await {
             match row_result {
@@ -272,6 +290,7 @@ async fn export_csv(
 
                     let mut wtr = csv::Writer::from_writer(&mut batch_buf);
                     if wtr.write_record(&fields).is_err() {
+                        stream_error = true;
                         break;
                     }
                     drop(wtr);
@@ -280,18 +299,31 @@ async fn export_csv(
                     if batch_count >= 100 {
                         let chunk = std::mem::take(&mut batch_buf);
                         if tx.send(Ok(bytes::Bytes::from(chunk))).await.is_err() {
-                            return;
+                            return; // Client disconnected — no error to signal
                         }
                         batch_count = 0;
                     }
                 }
-                Err(_) => break,
+                Err(e) => {
+                    tracing::error!(error = %e, "CSV export: row stream error mid-export");
+                    stream_error = true;
+                    break;
+                }
             }
         }
 
-        // Flush remaining
+        // Flush remaining data rows
         if !batch_buf.is_empty() {
-            let _ = tx.send(Ok(bytes::Bytes::from(batch_buf))).await;
+            let _ = tx.send(Ok(bytes::Bytes::from(std::mem::take(&mut batch_buf)))).await;
+        }
+
+        // Append an error sentinel so clients can detect truncation
+        if stream_error {
+            let _ = tx
+                .send(Ok(bytes::Bytes::from(
+                    "\n# ERROR: Export was interrupted. The data above is incomplete.\n",
+                )))
+                .await;
         }
     });
 
@@ -317,13 +349,24 @@ fn pg_value_to_csv_string(
 ) -> String {
     use sqlx::Row;
     match data_type {
-        "integer" | "smallint" | "bigint" => row
+        "smallint" => row
+            .try_get::<i16, _>(col)
+            .map(|v| v.to_string())
+            .unwrap_or_default(),
+        "integer" => row
+            .try_get::<i32, _>(col)
+            .map(|v| v.to_string())
+            .unwrap_or_default(),
+        "bigint" => row
             .try_get::<i64, _>(col)
             .map(|v| v.to_string())
             .unwrap_or_default(),
-        "real" | "double precision" | "numeric" => row
+        "real" | "double precision" => row
             .try_get::<f64, _>(col)
             .map(|v| v.to_string())
+            .unwrap_or_default(),
+        "numeric" => row
+            .try_get::<String, _>(col)
             .unwrap_or_default(),
         "boolean" => row
             .try_get::<bool, _>(col)
@@ -367,9 +410,11 @@ impl From<anyhow::Error> for AppError {
         if let Some(ve) = err.downcast_ref::<ValidationError>() {
             return Self::bad_request(ve.0.clone());
         }
+        // Log the real error for debugging; return a generic message to the client
+        tracing::error!(error = %err, "Internal server error");
         Self {
             status: axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            message: err.to_string(),
+            message: "Internal server error".to_string(),
         }
     }
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -314,6 +314,12 @@ async fn export_csv(
 
         if stream_error {
             tracing::warn!("CSV export: stream ended with error, output may be truncated");
+            // Signal truncation to the client as a valid CSV comment row
+            let _ = tx
+                .send(Ok(bytes::Bytes::from_static(
+                    b"# ERROR: Export incomplete - not all rows were exported. Please retry.\n",
+                )))
+                .await;
         }
     });
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,3 +1,6 @@
+pub mod setup;
+
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use axum::{
@@ -5,7 +8,7 @@ use axum::{
     extract::{Path, Query, State},
     routing::get,
 };
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::AppState;
 use crate::config::{display_name_column, display_name_table};
@@ -15,6 +18,69 @@ pub fn router() -> Router<Arc<AppState>> {
         .route("/tables", get(list_tables))
         .route("/tables/{table}/columns", get(get_columns))
         .route("/tables/{table}/rows", get(get_rows))
+        .route("/config/display", get(get_display_config))
+}
+
+#[derive(Serialize)]
+struct DisplayConfigResponse {
+    branding: BrandingResponse,
+    tables: HashMap<String, TableDisplayConfig>,
+}
+
+#[derive(Serialize)]
+struct BrandingResponse {
+    title: Option<String>,
+    subtitle: Option<String>,
+}
+
+#[derive(Serialize)]
+struct TableDisplayConfig {
+    display_name: String,
+    columns: HashMap<String, ColumnDisplayConfig>,
+}
+
+#[derive(Serialize)]
+struct ColumnDisplayConfig {
+    display_name: String,
+}
+
+async fn get_display_config(
+    State(state): State<Arc<AppState>>,
+) -> Result<Json<DisplayConfigResponse>, AppError> {
+    let all_tables = state.db.list_tables().await?;
+    let allowed_tables: Vec<_> = all_tables
+        .into_iter()
+        .filter(|t| state.config.tables.allows(&t.name))
+        .collect();
+
+    let mut tables = HashMap::new();
+    for table in &allowed_tables {
+        let columns_info = state.db.get_columns(&table.name).await?;
+        let columns: HashMap<String, ColumnDisplayConfig> = columns_info
+            .into_iter()
+            .map(|c| {
+                let display = display_name_column(&table.name, &c.name, &state.config.display);
+                (c.name, ColumnDisplayConfig { display_name: display })
+            })
+            .collect();
+
+        let display = display_name_table(&table.name, &state.config.display);
+        tables.insert(
+            table.name.clone(),
+            TableDisplayConfig {
+                display_name: display,
+                columns,
+            },
+        );
+    }
+
+    Ok(Json(DisplayConfigResponse {
+        branding: BrandingResponse {
+            title: state.config.branding.title.clone(),
+            subtitle: state.config.branding.subtitle.clone(),
+        },
+        tables,
+    }))
 }
 
 async fn list_tables(
@@ -40,6 +106,9 @@ async fn get_columns(
     State(state): State<Arc<AppState>>,
     Path(table): Path<String>,
 ) -> Result<Json<serde_json::Value>, AppError> {
+    if !state.config.tables.allows(&table) {
+        return Err(AppError::not_found(format!("Table '{table}' not found")));
+    }
     let raw_columns = state.db.get_columns(&table).await?;
     let columns: Vec<serde_json::Value> = raw_columns
         .into_iter()
@@ -81,6 +150,9 @@ async fn get_rows(
     Path(table): Path<String>,
     Query(params): Query<RowsQuery>,
 ) -> Result<Json<serde_json::Value>, AppError> {
+    if !state.config.tables.allows(&table) {
+        return Err(AppError::not_found(format!("Table '{table}' not found")));
+    }
     let result = state
         .db
         .query_rows(
@@ -96,23 +168,110 @@ async fn get_rows(
 }
 
 // Simple error type for API responses
-struct AppError(anyhow::Error);
+struct AppError {
+    status: axum::http::StatusCode,
+    message: String,
+}
+
+impl AppError {
+    fn not_found(message: impl Into<String>) -> Self {
+        Self {
+            status: axum::http::StatusCode::NOT_FOUND,
+            message: message.into(),
+        }
+    }
+}
 
 impl From<anyhow::Error> for AppError {
     fn from(err: anyhow::Error) -> Self {
-        Self(err)
+        Self {
+            status: axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            message: err.to_string(),
+        }
     }
 }
 
 impl axum::response::IntoResponse for AppError {
     fn into_response(self) -> axum::response::Response {
         let body = serde_json::json!({
-            "error": self.0.to_string(),
+            "error": self.message,
         });
-        (
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            Json(body),
-        )
-            .into_response()
+        (self.status, Json(body)).into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_config_response_serializes_with_branding() {
+        let response = DisplayConfigResponse {
+            branding: BrandingResponse {
+                title: Some("AutoConnect".into()),
+                subtitle: Some("Fleet Telemetry".into()),
+            },
+            tables: HashMap::new(),
+        };
+
+        let json = serde_json::to_value(&response).unwrap();
+        assert_eq!(json["branding"]["title"], "AutoConnect");
+        assert_eq!(json["branding"]["subtitle"], "Fleet Telemetry");
+        assert!(json["tables"].as_object().unwrap().is_empty());
+    }
+
+    #[test]
+    fn display_config_response_serializes_null_branding() {
+        let response = DisplayConfigResponse {
+            branding: BrandingResponse {
+                title: None,
+                subtitle: None,
+            },
+            tables: HashMap::new(),
+        };
+
+        let json = serde_json::to_value(&response).unwrap();
+        assert!(json["branding"]["title"].is_null());
+        assert!(json["branding"]["subtitle"].is_null());
+    }
+
+    #[test]
+    fn display_config_response_serializes_table_with_columns() {
+        let mut columns = HashMap::new();
+        columns.insert(
+            "posn_lat".into(),
+            ColumnDisplayConfig {
+                display_name: "Latitude".into(),
+            },
+        );
+        columns.insert(
+            "supervisor_id".into(),
+            ColumnDisplayConfig {
+                display_name: "Supervisor".into(),
+            },
+        );
+
+        let mut tables = HashMap::new();
+        tables.insert(
+            "vehicles_log".into(),
+            TableDisplayConfig {
+                display_name: "Fleet Log".into(),
+                columns,
+            },
+        );
+
+        let response = DisplayConfigResponse {
+            branding: BrandingResponse {
+                title: Some("AutoConnect".into()),
+                subtitle: None,
+            },
+            tables,
+        };
+
+        let json = serde_json::to_value(&response).unwrap();
+        let vl = &json["tables"]["vehicles_log"];
+        assert_eq!(vl["display_name"], "Fleet Log");
+        assert_eq!(vl["columns"]["posn_lat"]["display_name"], "Latitude");
+        assert_eq!(vl["columns"]["supervisor_id"]["display_name"], "Supervisor");
     }
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -5,14 +5,17 @@ use std::sync::Arc;
 
 use axum::{
     Json, Router,
+    body::Body,
     extract::{Path, Query, State},
+    http::header,
+    response::IntoResponse,
     routing::get,
 };
 use serde::{Deserialize, Serialize};
 
 use crate::AppState;
 use crate::config::{display_name_column, display_name_table};
-use crate::db::{RowQueryParams, ValidationError};
+use crate::db::{ExportQueryParams, RowQueryParams, ValidationError};
 
 pub fn router() -> Router<Arc<AppState>> {
     Router::new()
@@ -20,6 +23,7 @@ pub fn router() -> Router<Arc<AppState>> {
         .route("/tables/{table}/columns", get(get_columns))
         .route("/tables/{table}/rows", get(get_rows))
         .route("/config/display", get(get_display_config))
+        .route("/export/{table}/csv", get(export_csv))
 }
 
 #[derive(Serialize)]
@@ -181,6 +185,158 @@ async fn get_rows(
         })
         .await?;
     Ok(Json(serde_json::json!(result)))
+}
+
+async fn export_csv(
+    State(state): State<Arc<AppState>>,
+    Path(table): Path<String>,
+    Query(params): Query<RowsQuery>,
+    Query(all_params): Query<HashMap<String, String>>,
+) -> Result<impl IntoResponse, AppError> {
+    if !state.config.tables.allows(&table) {
+        return Err(AppError::not_found(format!("Table '{table}' not found")));
+    }
+
+    let pg_pool = state
+        .db
+        .pg_pool()
+        .ok_or_else(|| AppError::bad_request("CSV export not supported for this database type"))?
+        .clone();
+
+    let filters = parse_filters(&all_params);
+
+    // Fetch columns eagerly so we can build headers before spawning
+    let columns = state.db.get_columns(&table).await?;
+    let display_headers: Vec<String> = columns
+        .iter()
+        .map(|c| display_name_column(&table, &c.name, &state.config.display))
+        .collect();
+
+    let display_table = display_name_table(&table, &state.config.display)
+        .replace(' ', "_")
+        .to_lowercase();
+    let filename = format!("{display_table}.csv");
+
+    // Owned values for the spawned task
+    let sort_column = params.sort_column.clone();
+    let sort_direction = params.sort_direction.clone();
+    let search = params.search.clone();
+
+    let (tx, rx) = tokio::sync::mpsc::channel::<Result<bytes::Bytes, std::io::Error>>(32);
+
+    tokio::spawn(async move {
+        use futures::StreamExt;
+
+        // Write CSV header
+        let mut header_buf = Vec::new();
+        {
+            let mut wtr = csv::Writer::from_writer(&mut header_buf);
+            if wtr.write_record(&display_headers).is_err() {
+                return;
+            }
+            if wtr.flush().is_err() {
+                return;
+            }
+        }
+        if tx.send(Ok(bytes::Bytes::from(header_buf))).await.is_err() {
+            return;
+        }
+
+        // Build export params with owned data
+        let export_params = ExportQueryParams {
+            table: &table,
+            sort_column: sort_column.as_deref(),
+            sort_direction: sort_direction.as_deref(),
+            search: search.as_deref(),
+            filters: &filters,
+        };
+
+        let stream_result =
+            crate::db::postgres::export_rows_stream(&pg_pool, &export_params).await;
+
+        let (_cols, mut row_stream) = match stream_result {
+            Ok(v) => v,
+            Err(_) => return,
+        };
+
+        let mut batch_buf = Vec::with_capacity(8192);
+        let mut batch_count = 0u32;
+
+        while let Some(row_result) = row_stream.next().await {
+            match row_result {
+                Ok(row) => {
+                    let fields: Vec<String> = columns
+                        .iter()
+                        .map(|col| pg_value_to_csv_string(&row, &col.name, &col.data_type))
+                        .collect();
+
+                    let mut wtr = csv::Writer::from_writer(&mut batch_buf);
+                    if wtr.write_record(&fields).is_err() {
+                        break;
+                    }
+                    drop(wtr);
+                    batch_count += 1;
+
+                    if batch_count >= 100 {
+                        let chunk = std::mem::take(&mut batch_buf);
+                        if tx.send(Ok(bytes::Bytes::from(chunk))).await.is_err() {
+                            return;
+                        }
+                        batch_count = 0;
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+
+        // Flush remaining
+        if !batch_buf.is_empty() {
+            let _ = tx.send(Ok(bytes::Bytes::from(batch_buf))).await;
+        }
+    });
+
+    let stream = tokio_stream::wrappers::ReceiverStream::new(rx);
+    let body = Body::from_stream(stream);
+
+    Ok((
+        [
+            (header::CONTENT_TYPE, "text/csv; charset=utf-8".to_string()),
+            (
+                header::CONTENT_DISPOSITION,
+                format!("attachment; filename=\"{filename}\""),
+            ),
+        ],
+        body,
+    ))
+}
+
+fn pg_value_to_csv_string(
+    row: &sqlx::postgres::PgRow,
+    col: &str,
+    data_type: &str,
+) -> String {
+    use sqlx::Row;
+    match data_type {
+        "integer" | "smallint" | "bigint" => row
+            .try_get::<i64, _>(col)
+            .map(|v| v.to_string())
+            .unwrap_or_default(),
+        "real" | "double precision" | "numeric" => row
+            .try_get::<f64, _>(col)
+            .map(|v| v.to_string())
+            .unwrap_or_default(),
+        "boolean" => row
+            .try_get::<bool, _>(col)
+            .map(|v| if v { "Yes" } else { "No" }.to_string())
+            .unwrap_or_default(),
+        "json" | "jsonb" => row
+            .try_get::<serde_json::Value, _>(col)
+            .map(|v| v.to_string())
+            .unwrap_or_default(),
+        _ => row
+            .try_get::<String, _>(col)
+            .unwrap_or_default(),
+    }
 }
 
 // Simple error type for API responses
@@ -355,5 +511,87 @@ mod tests {
         let err = anyhow::anyhow!("something broke");
         let app_err = AppError::from(err);
         assert_eq!(app_err.status, axum::http::StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[test]
+    fn csv_header_uses_display_names() {
+        use crate::config::DisplayConfig;
+        use crate::db::ColumnInfo;
+
+        let columns = vec![
+            ColumnInfo {
+                name: "supervisor_id".into(),
+                data_type: "integer".into(),
+                display_type: "Number".into(),
+                is_nullable: false,
+                is_primary_key: false,
+            },
+            ColumnInfo {
+                name: "posn_lat".into(),
+                data_type: "double precision".into(),
+                display_type: "Decimal".into(),
+                is_nullable: true,
+                is_primary_key: false,
+            },
+        ];
+
+        let mut col_overrides = HashMap::new();
+        col_overrides.insert("posn_lat".to_string(), "Latitude".to_string());
+        let mut columns_map = HashMap::new();
+        columns_map.insert("vehicles_log".to_string(), col_overrides);
+
+        let config = DisplayConfig {
+            tables: HashMap::new(),
+            columns: columns_map,
+        };
+
+        let headers: Vec<String> = columns
+            .iter()
+            .map(|c| display_name_column("vehicles_log", &c.name, &config))
+            .collect();
+
+        assert_eq!(headers, vec!["Supervisor", "Latitude"]);
+    }
+
+    #[test]
+    fn csv_writes_valid_output() {
+        let headers = vec!["Name", "Age", "Active"];
+        let rows = vec![
+            vec!["Alice", "30", "Yes"],
+            vec!["Bob", "25", "No"],
+        ];
+
+        let mut buf = Vec::new();
+        {
+            let mut wtr = csv::Writer::from_writer(&mut buf);
+            wtr.write_record(&headers).unwrap();
+            for row in &rows {
+                wtr.write_record(row).unwrap();
+            }
+            wtr.flush().unwrap();
+        }
+
+        let output = String::from_utf8(buf).unwrap();
+        assert!(output.starts_with("Name,Age,Active"));
+        assert!(output.contains("Alice,30,Yes"));
+        assert!(output.contains("Bob,25,No"));
+    }
+
+    #[test]
+    fn csv_export_filename_uses_display_name() {
+        use crate::config::DisplayConfig;
+
+        let mut tables = HashMap::new();
+        tables.insert("vehicles_log".to_string(), "Fleet Log".to_string());
+        let config = DisplayConfig {
+            tables,
+            columns: HashMap::new(),
+        };
+
+        let display = display_name_table("vehicles_log", &config)
+            .replace(' ', "_")
+            .to_lowercase();
+        assert_eq!(display, "fleet_log");
+        assert_eq!(format!("{display}.csv"), "fleet_log.csv");
     }
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -8,6 +8,7 @@ use axum::{
 use serde::Deserialize;
 
 use crate::AppState;
+use crate::config::{display_name_column, display_name_table};
 
 pub fn router() -> Router<Arc<AppState>> {
     Router::new()
@@ -19,7 +20,19 @@ pub fn router() -> Router<Arc<AppState>> {
 async fn list_tables(
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<serde_json::Value>, AppError> {
-    let tables = state.db.list_tables().await?;
+    let all_tables = state.db.list_tables().await?;
+    let tables: Vec<serde_json::Value> = all_tables
+        .into_iter()
+        .filter(|t| state.config.tables.allows(&t.name))
+        .map(|t| {
+            let display = display_name_table(&t.name, &state.config.display);
+            serde_json::json!({
+                "name": t.name,
+                "display_name": display,
+                "row_count_estimate": t.row_count_estimate,
+            })
+        })
+        .collect();
     Ok(Json(serde_json::json!({ "tables": tables })))
 }
 
@@ -27,7 +40,21 @@ async fn get_columns(
     State(state): State<Arc<AppState>>,
     Path(table): Path<String>,
 ) -> Result<Json<serde_json::Value>, AppError> {
-    let columns = state.db.get_columns(&table).await?;
+    let raw_columns = state.db.get_columns(&table).await?;
+    let columns: Vec<serde_json::Value> = raw_columns
+        .into_iter()
+        .map(|c| {
+            let display = display_name_column(&table, &c.name, &state.config.display);
+            serde_json::json!({
+                "name": c.name,
+                "display_name": display,
+                "data_type": c.data_type,
+                "display_type": c.display_type,
+                "is_nullable": c.is_nullable,
+                "is_primary_key": c.is_primary_key,
+            })
+        })
+        .collect();
     Ok(Json(serde_json::json!({ "columns": columns })))
 }
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -267,11 +267,6 @@ async fn export_csv(
             Ok(v) => v,
             Err(e) => {
                 tracing::error!(error = %e, "CSV export: failed to open row stream");
-                let _ = tx
-                    .send(Ok(bytes::Bytes::from(
-                        "\n# ERROR: Export failed before streaming rows. The data above is incomplete.\n",
-                    )))
-                    .await;
                 return;
             }
         };
@@ -317,13 +312,8 @@ async fn export_csv(
             let _ = tx.send(Ok(bytes::Bytes::from(std::mem::take(&mut batch_buf)))).await;
         }
 
-        // Append an error sentinel so clients can detect truncation
         if stream_error {
-            let _ = tx
-                .send(Ok(bytes::Bytes::from(
-                    "\n# ERROR: Export was interrupted. The data above is incomplete.\n",
-                )))
-                .await;
+            tracing::warn!("CSV export: stream ended with error, output may be truncated");
         }
     });
 

--- a/src/api/setup.rs
+++ b/src/api/setup.rs
@@ -106,11 +106,35 @@ struct SaveConfigResponse {
 
 async fn save_config(Json(req): Json<SaveConfigRequest>) -> Json<SaveConfigResponse> {
     // Validate the database kind
-    if let Err(e) = parse_db_kind(&req.database.kind) {
-        return Json(SaveConfigResponse {
-            success: false,
-            error: Some(e),
-        });
+    let kind = match parse_db_kind(&req.database.kind) {
+        Ok(k) => k,
+        Err(e) => {
+            return Json(SaveConfigResponse {
+                success: false,
+                error: Some(e),
+            });
+        }
+    };
+
+    // Verify the connection is reachable before writing config
+    match kind {
+        DatabaseKind::Postgres => {
+            if let Err(e) = postgres::test_connection(&req.database.url).await {
+                tracing::error!(error = %e, "save_config: connection test failed");
+                return Json(SaveConfigResponse {
+                    success: false,
+                    error: Some(
+                        "Cannot connect to the database. Check your connection URL and ensure the database is running.".to_string(),
+                    ),
+                });
+            }
+        }
+        DatabaseKind::Sqlite => {
+            return Json(SaveConfigResponse {
+                success: false,
+                error: Some("SQLite support coming in v0.2".to_string()),
+            });
+        }
     }
 
     // Build a typed struct and serialize via toml to prevent injection
@@ -270,26 +294,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn save_config_writes_valid_toml() {
-        let _guard = crate::testutil::cwd_lock()
-            .lock()
-            .expect("cwd lock should not be poisoned");
-
-        let temp_dir = std::env::temp_dir().join(format!(
-            "seeki-setup-test-{}",
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
-        std::fs::create_dir_all(&temp_dir).unwrap();
-        let original_dir = std::env::current_dir().unwrap();
-        std::env::set_current_dir(&temp_dir).unwrap();
-
+    async fn save_config_rejects_unreachable_db() {
         let app = setup_router();
         let body = serde_json::json!({
             "server": { "host": "0.0.0.0", "port": 8080 },
-            "database": { "kind": "postgres", "url": "postgres://u:p@localhost/db", "max_connections": 3 }
+            "database": { "kind": "postgres", "url": "postgres://u:p@localhost:59999/db", "max_connections": 3 }
         });
 
         let resp = app
@@ -306,19 +315,8 @@ mod tests {
 
         let bytes = resp.into_body().collect().await.unwrap().to_bytes();
         let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
-        assert_eq!(json["success"], true);
-
-        // Verify the written file parses as valid config
-        let content = std::fs::read_to_string(temp_dir.join("seeki.toml")).unwrap();
-        let config = AppConfig::parse(&content).unwrap();
-        assert_eq!(config.server.host, "0.0.0.0");
-        assert_eq!(config.server.port, 8080);
-        assert_eq!(config.database.url, "postgres://u:p@localhost/db");
-        assert_eq!(config.database.max_connections, 3);
-
-        // Cleanup
-        std::env::set_current_dir(&original_dir).unwrap();
-        std::fs::remove_dir_all(&temp_dir).unwrap();
+        assert_eq!(json["success"], false);
+        assert!(json["error"].as_str().unwrap().contains("Cannot connect"));
     }
 
     #[tokio::test]

--- a/src/api/setup.rs
+++ b/src/api/setup.rs
@@ -1,0 +1,329 @@
+use axum::{Json, Router, routing::post};
+use serde::{Deserialize, Serialize};
+
+use crate::config::{AppConfig, DatabaseKind};
+use crate::db::postgres;
+
+pub fn router() -> Router {
+    Router::new()
+        .route("/setup/test-connection", post(test_connection))
+        .route("/setup/save", post(save_config))
+}
+
+#[derive(Deserialize)]
+struct TestConnectionRequest {
+    kind: String,
+    url: String,
+}
+
+#[derive(Serialize)]
+struct TestConnectionResponse {
+    success: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tables: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+}
+
+async fn test_connection(
+    Json(req): Json<TestConnectionRequest>,
+) -> Json<TestConnectionResponse> {
+    let kind = match parse_db_kind(&req.kind) {
+        Ok(k) => k,
+        Err(e) => {
+            return Json(TestConnectionResponse {
+                success: false,
+                tables: None,
+                error: Some(e),
+            });
+        }
+    };
+
+    match kind {
+        DatabaseKind::Postgres => match postgres::test_connection(&req.url).await {
+            Ok(tables) => Json(TestConnectionResponse {
+                success: true,
+                tables: Some(tables),
+                error: None,
+            }),
+            Err(e) => Json(TestConnectionResponse {
+                success: false,
+                tables: None,
+                error: Some(e.to_string()),
+            }),
+        },
+        DatabaseKind::Sqlite => Json(TestConnectionResponse {
+            success: false,
+            tables: None,
+            error: Some("SQLite support coming in v0.2".to_string()),
+        }),
+    }
+}
+
+#[derive(Deserialize)]
+struct SaveConfigRequest {
+    server: SaveServerConfig,
+    database: SaveDatabaseConfig,
+}
+
+#[derive(Deserialize)]
+struct SaveServerConfig {
+    #[serde(default = "default_host")]
+    host: String,
+    #[serde(default = "default_port")]
+    port: u16,
+}
+
+#[derive(Deserialize)]
+struct SaveDatabaseConfig {
+    kind: String,
+    url: String,
+    #[serde(default = "default_max_connections")]
+    max_connections: u32,
+}
+
+fn default_host() -> String {
+    "127.0.0.1".to_string()
+}
+
+fn default_port() -> u16 {
+    3141
+}
+
+fn default_max_connections() -> u32 {
+    5
+}
+
+#[derive(Serialize)]
+struct SaveConfigResponse {
+    success: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+}
+
+async fn save_config(Json(req): Json<SaveConfigRequest>) -> Json<SaveConfigResponse> {
+    // Validate the database kind
+    if let Err(e) = parse_db_kind(&req.database.kind) {
+        return Json(SaveConfigResponse {
+            success: false,
+            error: Some(e),
+        });
+    }
+
+    let toml_content = format!(
+        r#"[server]
+host = "{host}"
+port = {port}
+
+[database]
+kind = "{kind}"
+url = "{url}"
+max_connections = {max_connections}
+"#,
+        host = req.server.host,
+        port = req.server.port,
+        kind = req.database.kind,
+        url = req.database.url,
+        max_connections = req.database.max_connections,
+    );
+
+    // Validate the generated TOML parses as a valid AppConfig
+    if let Err(e) = AppConfig::parse(&toml_content) {
+        return Json(SaveConfigResponse {
+            success: false,
+            error: Some(format!("Generated config is invalid: {e}")),
+        });
+    }
+
+    match std::fs::write("seeki.toml", &toml_content) {
+        Ok(()) => Json(SaveConfigResponse {
+            success: true,
+            error: None,
+        }),
+        Err(e) => Json(SaveConfigResponse {
+            success: false,
+            error: Some(format!("Failed to write seeki.toml: {e}")),
+        }),
+    }
+}
+
+fn parse_db_kind(kind: &str) -> Result<DatabaseKind, String> {
+    match kind {
+        "postgres" => Ok(DatabaseKind::Postgres),
+        "sqlite" => Ok(DatabaseKind::Sqlite),
+        other => Err(format!("Unsupported database kind: {other}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{body::Body, http::Request};
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+
+    fn setup_router() -> Router {
+        router()
+    }
+
+    #[tokio::test]
+    async fn test_connection_invalid_kind() {
+        let app = setup_router();
+        let body = serde_json::json!({
+            "kind": "mysql",
+            "url": "mysql://localhost/db"
+        });
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/setup/test-connection")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_string(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), 200);
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["success"], false);
+        assert!(json["error"].as_str().unwrap().contains("Unsupported"));
+    }
+
+    #[tokio::test]
+    async fn test_connection_sqlite_not_supported() {
+        let app = setup_router();
+        let body = serde_json::json!({
+            "kind": "sqlite",
+            "url": "sqlite:test.db"
+        });
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/setup/test-connection")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_string(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["success"], false);
+        assert!(json["error"].as_str().unwrap().contains("v0.2"));
+    }
+
+    #[tokio::test]
+    async fn test_connection_bad_postgres_url() {
+        let app = setup_router();
+        let body = serde_json::json!({
+            "kind": "postgres",
+            "url": "postgres://invalid:invalid@localhost:59999/nonexistent"
+        });
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/setup/test-connection")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_string(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["success"], false);
+        assert!(json["error"].is_string());
+    }
+
+    /// Global lock to prevent CWD races between tests that change the working directory.
+    fn cwd_lock() -> &'static std::sync::Mutex<()> {
+        static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+        LOCK.get_or_init(|| std::sync::Mutex::new(()))
+    }
+
+    #[tokio::test]
+    async fn save_config_writes_valid_toml() {
+        let _guard = cwd_lock().lock().expect("cwd lock should not be poisoned");
+
+        let temp_dir = std::env::temp_dir().join(format!(
+            "seeki-setup-test-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&temp_dir).unwrap();
+        let original_dir = std::env::current_dir().unwrap();
+        std::env::set_current_dir(&temp_dir).unwrap();
+
+        let app = setup_router();
+        let body = serde_json::json!({
+            "server": { "host": "0.0.0.0", "port": 8080 },
+            "database": { "kind": "postgres", "url": "postgres://u:p@localhost/db", "max_connections": 3 }
+        });
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/setup/save")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_string(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["success"], true);
+
+        // Verify the written file parses as valid config
+        let content = std::fs::read_to_string(temp_dir.join("seeki.toml")).unwrap();
+        let config = AppConfig::parse(&content).unwrap();
+        assert_eq!(config.server.host, "0.0.0.0");
+        assert_eq!(config.server.port, 8080);
+        assert_eq!(config.database.url, "postgres://u:p@localhost/db");
+        assert_eq!(config.database.max_connections, 3);
+
+        // Cleanup
+        std::env::set_current_dir(&original_dir).unwrap();
+        std::fs::remove_dir_all(&temp_dir).unwrap();
+    }
+
+    #[tokio::test]
+    async fn save_config_invalid_kind() {
+        let app = setup_router();
+        let body = serde_json::json!({
+            "server": { "host": "127.0.0.1", "port": 3141 },
+            "database": { "kind": "mysql", "url": "mysql://localhost/db" }
+        });
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/setup/save")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_string(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["success"], false);
+        assert!(json["error"].as_str().unwrap().contains("Unsupported"));
+    }
+}

--- a/src/api/setup.rs
+++ b/src/api/setup.rs
@@ -137,51 +137,15 @@ async fn save_config(Json(req): Json<SaveConfigRequest>) -> Json<SaveConfigRespo
         }
     }
 
-    // Build a typed struct and serialize via toml to prevent injection
-    let config_to_write = toml::value::Table::from_iter([
-        (
-            "server".to_string(),
-            toml::Value::Table(toml::value::Table::from_iter([
-                ("host".to_string(), toml::Value::String(req.server.host)),
-                (
-                    "port".to_string(),
-                    toml::Value::Integer(req.server.port as i64),
-                ),
-            ])),
-        ),
-        (
-            "database".to_string(),
-            toml::Value::Table(toml::value::Table::from_iter([
-                (
-                    "kind".to_string(),
-                    toml::Value::String(req.database.kind),
-                ),
-                ("url".to_string(), toml::Value::String(req.database.url)),
-                (
-                    "max_connections".to_string(),
-                    toml::Value::Integer(req.database.max_connections as i64),
-                ),
-            ])),
-        ),
-    ]);
-
-    let toml_content = match toml::to_string_pretty(&config_to_write) {
+    let toml_content = match build_config_toml(&req) {
         Ok(s) => s,
         Err(e) => {
             return Json(SaveConfigResponse {
                 success: false,
-                error: Some(format!("Failed to serialize config: {e}")),
+                error: Some(e),
             });
         }
     };
-
-    // Validate the generated TOML parses as a valid AppConfig
-    if let Err(e) = AppConfig::parse(&toml_content) {
-        return Json(SaveConfigResponse {
-            success: false,
-            error: Some(format!("Generated config is invalid: {e}")),
-        });
-    }
 
     match std::fs::write("seeki.toml", &toml_content) {
         Ok(()) => Json(SaveConfigResponse {
@@ -193,6 +157,46 @@ async fn save_config(Json(req): Json<SaveConfigRequest>) -> Json<SaveConfigRespo
             error: Some(format!("Failed to write seeki.toml: {e}")),
         }),
     }
+}
+
+/// Build a typed TOML config from the save request, serialize it, and validate
+/// it round-trips through `AppConfig::parse`. Returns the TOML string on success.
+fn build_config_toml(req: &SaveConfigRequest) -> Result<String, String> {
+    let config_to_write = toml::value::Table::from_iter([
+        (
+            "server".to_string(),
+            toml::Value::Table(toml::value::Table::from_iter([
+                ("host".to_string(), toml::Value::String(req.server.host.clone())),
+                (
+                    "port".to_string(),
+                    toml::Value::Integer(req.server.port as i64),
+                ),
+            ])),
+        ),
+        (
+            "database".to_string(),
+            toml::Value::Table(toml::value::Table::from_iter([
+                (
+                    "kind".to_string(),
+                    toml::Value::String(req.database.kind.clone()),
+                ),
+                ("url".to_string(), toml::Value::String(req.database.url.clone())),
+                (
+                    "max_connections".to_string(),
+                    toml::Value::Integer(req.database.max_connections as i64),
+                ),
+            ])),
+        ),
+    ]);
+
+    let toml_content = toml::to_string_pretty(&config_to_write)
+        .map_err(|e| format!("Failed to serialize config: {e}"))?;
+
+    // Validate the generated TOML parses as a valid AppConfig
+    AppConfig::parse(&toml_content)
+        .map_err(|e| format!("Generated config is invalid: {e}"))?;
+
+    Ok(toml_content)
 }
 
 fn parse_db_kind(kind: &str) -> Result<DatabaseKind, String> {
@@ -317,6 +321,67 @@ mod tests {
         let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(json["success"], false);
         assert!(json["error"].as_str().unwrap().contains("Cannot connect"));
+    }
+
+    #[test]
+    fn build_config_toml_success_roundtrips() {
+        let req = SaveConfigRequest {
+            server: SaveServerConfig {
+                host: "0.0.0.0".to_string(),
+                port: 8080,
+            },
+            database: SaveDatabaseConfig {
+                kind: "postgres".to_string(),
+                url: "postgres://user:pass@localhost:5432/mydb".to_string(),
+                max_connections: 10,
+            },
+        };
+
+        let toml_content = build_config_toml(&req).expect("should produce valid TOML");
+
+        // Verify the TOML contains the expected values
+        let parsed: toml::Value = toml::from_str(&toml_content).unwrap();
+        assert_eq!(parsed["server"]["host"].as_str().unwrap(), "0.0.0.0");
+        assert_eq!(parsed["server"]["port"].as_integer().unwrap(), 8080);
+        assert_eq!(parsed["database"]["kind"].as_str().unwrap(), "postgres");
+        assert_eq!(
+            parsed["database"]["url"].as_str().unwrap(),
+            "postgres://user:pass@localhost:5432/mydb"
+        );
+        assert_eq!(parsed["database"]["max_connections"].as_integer().unwrap(), 10);
+
+        // Verify it round-trips through AppConfig::parse (already done inside
+        // build_config_toml, but confirm the output is also re-parseable)
+        AppConfig::parse(&toml_content).expect("generated TOML should parse as AppConfig");
+    }
+
+    #[test]
+    fn build_config_toml_writes_to_disk() {
+        let req = SaveConfigRequest {
+            server: SaveServerConfig {
+                host: "127.0.0.1".to_string(),
+                port: 3141,
+            },
+            database: SaveDatabaseConfig {
+                kind: "postgres".to_string(),
+                url: "postgres://u:p@localhost/db".to_string(),
+                max_connections: 5,
+            },
+        };
+
+        let toml_content = build_config_toml(&req).expect("should produce valid TOML");
+
+        let dir = std::env::temp_dir().join("seeki-test-save-config");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("seeki.toml");
+        std::fs::write(&path, &toml_content).expect("should write to temp file");
+
+        let read_back = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(read_back, toml_content);
+        AppConfig::parse(&read_back).expect("written file should parse as AppConfig");
+
+        // Cleanup
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[tokio::test]

--- a/src/api/setup.rs
+++ b/src/api/setup.rs
@@ -46,11 +46,14 @@ async fn test_connection(
                 tables: Some(tables),
                 error: None,
             }),
-            Err(e) => Json(TestConnectionResponse {
-                success: false,
-                tables: None,
-                error: Some(e.to_string()),
-            }),
+            Err(e) => {
+                tracing::error!(error = %e, "test_connection failed");
+                Json(TestConnectionResponse {
+                    success: false,
+                    tables: None,
+                    error: Some("Failed to connect to database. Check your connection URL and ensure the database is running.".to_string()),
+                })
+            }
         },
         DatabaseKind::Sqlite => Json(TestConnectionResponse {
             success: false,
@@ -110,22 +113,43 @@ async fn save_config(Json(req): Json<SaveConfigRequest>) -> Json<SaveConfigRespo
         });
     }
 
-    let toml_content = format!(
-        r#"[server]
-host = "{host}"
-port = {port}
+    // Build a typed struct and serialize via toml to prevent injection
+    let config_to_write = toml::value::Table::from_iter([
+        (
+            "server".to_string(),
+            toml::Value::Table(toml::value::Table::from_iter([
+                ("host".to_string(), toml::Value::String(req.server.host)),
+                (
+                    "port".to_string(),
+                    toml::Value::Integer(req.server.port as i64),
+                ),
+            ])),
+        ),
+        (
+            "database".to_string(),
+            toml::Value::Table(toml::value::Table::from_iter([
+                (
+                    "kind".to_string(),
+                    toml::Value::String(req.database.kind),
+                ),
+                ("url".to_string(), toml::Value::String(req.database.url)),
+                (
+                    "max_connections".to_string(),
+                    toml::Value::Integer(req.database.max_connections as i64),
+                ),
+            ])),
+        ),
+    ]);
 
-[database]
-kind = "{kind}"
-url = "{url}"
-max_connections = {max_connections}
-"#,
-        host = req.server.host,
-        port = req.server.port,
-        kind = req.database.kind,
-        url = req.database.url,
-        max_connections = req.database.max_connections,
-    );
+    let toml_content = match toml::to_string_pretty(&config_to_write) {
+        Ok(s) => s,
+        Err(e) => {
+            return Json(SaveConfigResponse {
+                success: false,
+                error: Some(format!("Failed to serialize config: {e}")),
+            });
+        }
+    };
 
     // Validate the generated TOML parses as a valid AppConfig
     if let Err(e) = AppConfig::parse(&toml_content) {
@@ -245,15 +269,11 @@ mod tests {
         assert!(json["error"].is_string());
     }
 
-    /// Global lock to prevent CWD races between tests that change the working directory.
-    fn cwd_lock() -> &'static std::sync::Mutex<()> {
-        static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
-        LOCK.get_or_init(|| std::sync::Mutex::new(()))
-    }
-
     #[tokio::test]
     async fn save_config_writes_valid_toml() {
-        let _guard = cwd_lock().lock().expect("cwd lock should not be poisoned");
+        let _guard = crate::testutil::cwd_lock()
+            .lock()
+            .expect("cwd lock should not be poisoned");
 
         let temp_dir = std::env::temp_dir().join(format!(
             "seeki-setup-test-{}",

--- a/src/config.rs
+++ b/src/config.rs
@@ -156,11 +156,41 @@ fn title_case(segment: &str) -> String {
     }
 }
 
+/// Error type distinguishing "no config file" from "config file exists but is invalid".
+#[derive(Debug)]
+pub enum ConfigLoadError {
+    /// No config file found at any candidate path — safe to enter setup mode.
+    NotFound,
+    /// Config file exists but failed to read or parse — should NOT enter setup mode.
+    Invalid { path: PathBuf, source: anyhow::Error },
+}
+
+impl std::fmt::Display for ConfigLoadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotFound => write!(f, "No config file found"),
+            Self::Invalid { path, source } => {
+                write!(f, "Invalid config at {}: {source}", path.display())
+            }
+        }
+    }
+}
+
+impl std::error::Error for ConfigLoadError {}
+
 impl AppConfig {
-    pub fn load() -> anyhow::Result<Self> {
+    pub fn load() -> Result<Self, ConfigLoadError> {
         let config_path = Self::find_config_file()?;
-        let content = std::fs::read_to_string(&config_path)?;
-        let config = Self::parse(&content)?;
+        let content = std::fs::read_to_string(&config_path).map_err(|e| {
+            ConfigLoadError::Invalid {
+                path: config_path.clone(),
+                source: e.into(),
+            }
+        })?;
+        let config = Self::parse(&content).map_err(|e| ConfigLoadError::Invalid {
+            path: config_path.clone(),
+            source: e,
+        })?;
         tracing::info!("Loaded config from {}", config_path.display());
         Ok(config)
     }
@@ -169,7 +199,7 @@ impl AppConfig {
         Ok(toml::from_str(content)?)
     }
 
-    fn find_config_file() -> anyhow::Result<PathBuf> {
+    fn find_config_file() -> Result<PathBuf, ConfigLoadError> {
         let candidates = [
             PathBuf::from("seeki.toml"),
             dirs_next::config_dir()
@@ -183,16 +213,7 @@ impl AppConfig {
             }
         }
 
-        anyhow::bail!(
-            "No config file found. Create seeki.toml in the current directory.\n\
-             Example:\n\n\
-             [server]\n\
-             host = \"127.0.0.1\"\n\
-             port = 3141\n\n\
-             [database]\n\
-             kind = \"postgres\"\n\
-             url = \"postgres://user:pass@localhost:5432/mydb\"\n"
-        )
+        Err(ConfigLoadError::NotFound)
     }
 }
 
@@ -201,7 +222,6 @@ mod tests {
     use super::*;
     use std::fs;
     use std::path::PathBuf;
-    use std::sync::{Mutex, OnceLock};
     use std::time::{SystemTime, UNIX_EPOCH};
 
     const MINIMAL_CONFIG: &str = r#"
@@ -469,15 +489,15 @@ subtitle = "Fleet Telemetry"
     }
 
     fn load_config(content: &str) -> AppConfig {
-        let _guard = cwd_lock().lock().expect("cwd lock should not be poisoned");
+        let _guard = crate::testutil::cwd_lock()
+            .lock()
+            .expect("cwd lock should not be poisoned");
         let _temp_dir = TempConfigDir::new(content);
 
-        AppConfig::load().expect("config should load")
-    }
-
-    fn cwd_lock() -> &'static Mutex<()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
+        match AppConfig::load() {
+            Ok(config) => config,
+            Err(e) => panic!("config should load: {e}"),
+        }
     }
 
     struct TempConfigDir {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,10 +1,69 @@
 use serde::Deserialize;
+use std::collections::HashMap;
 use std::path::PathBuf;
 
 #[derive(Debug, Deserialize)]
 pub struct AppConfig {
     pub server: ServerConfig,
     pub database: DatabaseConfig,
+    #[serde(default)]
+    pub tables: TablesConfig,
+    #[serde(default)]
+    pub display: DisplayConfig,
+    #[serde(default)]
+    pub branding: BrandingConfig,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct TablesConfig {
+    #[serde(default)]
+    pub include: Option<Vec<String>>,
+    #[serde(default)]
+    pub exclude: Option<Vec<String>>,
+}
+
+impl TablesConfig {
+    pub fn allows(&self, table: &str) -> bool {
+        let included = match &self.include {
+            Some(include) => include.iter().any(|candidate| candidate == table),
+            None => true,
+        };
+        let excluded = match &self.exclude {
+            Some(exclude) => exclude.iter().any(|candidate| candidate == table),
+            None => false,
+        };
+
+        included && !excluded
+    }
+
+    pub fn warn_overlaps(&self) {
+        if let (Some(include), Some(exclude)) = (&self.include, &self.exclude) {
+            for table in include {
+                if exclude.contains(table) {
+                    tracing::warn!(
+                        table = %table,
+                        "table appears in both [tables] include and exclude — it will be excluded"
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct DisplayConfig {
+    #[serde(default)]
+    pub tables: HashMap<String, String>,
+    #[serde(default)]
+    pub columns: HashMap<String, HashMap<String, String>>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct BrandingConfig {
+    #[serde(default)]
+    pub title: Option<String>,
+    #[serde(default)]
+    pub subtitle: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -44,13 +103,70 @@ fn default_max_connections() -> u32 {
     5
 }
 
+pub fn display_name_table(table: &str, config: &DisplayConfig) -> String {
+    config
+        .tables
+        .get(table)
+        .cloned()
+        .unwrap_or_else(|| casualify(table, false))
+}
+
+pub fn display_name_column(table: &str, column: &str, config: &DisplayConfig) -> String {
+    config
+        .columns
+        .get(table)
+        .and_then(|columns| columns.get(column))
+        .cloned()
+        .unwrap_or_else(|| casualify(column, true))
+}
+
+fn casualify(name: &str, drop_id_suffix: bool) -> String {
+    let normalized = if drop_id_suffix {
+        name.strip_suffix("_id").unwrap_or(name)
+    } else {
+        name
+    };
+
+    let result: String = normalized
+        .split('_')
+        .filter(|segment| !segment.is_empty())
+        .map(title_case)
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    if result.is_empty() {
+        name.to_string()
+    } else {
+        result
+    }
+}
+
+fn title_case(segment: &str) -> String {
+    if segment.chars().all(|c| c.is_ascii_uppercase() || c.is_ascii_digit()) && segment.len() > 1 {
+        return segment.to_string();
+    }
+    let mut chars = segment.chars();
+    match chars.next() {
+        Some(first) => format!(
+            "{}{}",
+            first.to_uppercase(),
+            chars.as_str().to_ascii_lowercase()
+        ),
+        None => String::new(),
+    }
+}
+
 impl AppConfig {
     pub fn load() -> anyhow::Result<Self> {
         let config_path = Self::find_config_file()?;
         let content = std::fs::read_to_string(&config_path)?;
-        let config: Self = toml::from_str(&content)?;
+        let config = Self::parse(&content)?;
         tracing::info!("Loaded config from {}", config_path.display());
         Ok(config)
+    }
+
+    fn parse(content: &str) -> anyhow::Result<Self> {
+        Ok(toml::from_str(content)?)
     }
 
     fn find_config_file() -> anyhow::Result<PathBuf> {
@@ -77,5 +193,325 @@ impl AppConfig {
              kind = \"postgres\"\n\
              url = \"postgres://user:pass@localhost:5432/mydb\"\n"
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::sync::{Mutex, OnceLock};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    const MINIMAL_CONFIG: &str = r#"
+[server]
+host = "127.0.0.1"
+port = 3141
+
+[database]
+kind = "postgres"
+url = "postgres://user:pass@localhost:5432/mydb"
+"#;
+
+    const FULL_CONFIG: &str = r#"
+[server]
+host = "0.0.0.0"
+port = 4000
+
+[database]
+kind = "sqlite"
+url = "sqlite:seeki.db"
+max_connections = 10
+
+[tables]
+include = ["vehicles_log", "drivers", "audit_log"]
+exclude = ["audit_log"]
+
+[display.tables]
+vehicles_log = "Fleet Log"
+
+[display.columns.vehicles_log]
+posn_lat = "Latitude"
+supervisor_id = "Supervisor"
+
+[branding]
+title = "AutoConnect"
+subtitle = "Fleet Telemetry"
+"#;
+
+    #[test]
+    fn minimal_config_loads_with_defaults() {
+        let config = load_config(MINIMAL_CONFIG);
+
+        assert!(config.tables.include.is_none());
+        assert!(config.tables.exclude.is_none());
+        assert!(config.display.tables.is_empty());
+        assert!(config.display.columns.is_empty());
+        assert!(config.branding.title.is_none());
+        assert!(config.branding.subtitle.is_none());
+    }
+
+    #[test]
+    fn full_config_loads_all_extensions() {
+        let config = load_config(FULL_CONFIG);
+
+        assert_eq!(
+            config
+                .tables
+                .include
+                .as_ref()
+                .expect("include should be set"),
+            &vec![
+                "vehicles_log".to_string(),
+                "drivers".to_string(),
+                "audit_log".to_string(),
+            ]
+        );
+        assert_eq!(
+            config
+                .tables
+                .exclude
+                .as_ref()
+                .expect("exclude should be set"),
+            &vec!["audit_log".to_string()]
+        );
+        assert_eq!(
+            config
+                .display
+                .tables
+                .get("vehicles_log")
+                .map(String::as_str),
+            Some("Fleet Log")
+        );
+        assert_eq!(
+            config
+                .display
+                .columns
+                .get("vehicles_log")
+                .and_then(|columns| columns.get("posn_lat"))
+                .map(String::as_str),
+            Some("Latitude")
+        );
+        assert_eq!(config.branding.title.as_deref(), Some("AutoConnect"));
+        assert_eq!(config.branding.subtitle.as_deref(), Some("Fleet Telemetry"));
+    }
+
+    #[test]
+    fn tables_config_applies_include_then_exclude() {
+        let config = TablesConfig {
+            include: Some(vec!["a".into(), "b".into(), "c".into()]),
+            exclude: Some(vec!["c".into()]),
+        };
+
+        assert_eq!(
+            effective_tables(&config, &["a", "b", "c", "d"]),
+            vec!["a", "b"]
+        );
+    }
+
+    #[test]
+    fn tables_config_applies_include_only() {
+        let config = TablesConfig {
+            include: Some(vec!["a".into(), "b".into()]),
+            exclude: None,
+        };
+
+        assert_eq!(
+            effective_tables(&config, &["a", "b", "c", "d"]),
+            vec!["a", "b"]
+        );
+    }
+
+    #[test]
+    fn tables_config_applies_exclude_only() {
+        let config = TablesConfig {
+            include: None,
+            exclude: Some(vec!["c".into()]),
+        };
+
+        assert_eq!(
+            effective_tables(&config, &["a", "b", "c", "d"]),
+            vec!["a", "b", "d"]
+        );
+    }
+
+    #[test]
+    fn tables_config_allows_all_tables_when_unset() {
+        let config = TablesConfig::default();
+
+        assert_eq!(
+            effective_tables(&config, &["a", "b", "c"]),
+            vec!["a", "b", "c"]
+        );
+    }
+
+    #[test]
+    fn column_display_name_uses_title_case_heuristic() {
+        assert_eq!(
+            display_name_column("my_table", "some_column", &DisplayConfig::default()),
+            "Some Column"
+        );
+    }
+
+    #[test]
+    fn column_display_name_drops_id_suffix() {
+        assert_eq!(
+            display_name_column("vehicles_log", "supervisor_id", &DisplayConfig::default()),
+            "Supervisor"
+        );
+    }
+
+    #[test]
+    fn column_display_name_prefers_override() {
+        let config = AppConfig::parse(FULL_CONFIG).expect("full config should parse");
+
+        assert_eq!(
+            display_name_column("vehicles_log", "posn_lat", &config.display),
+            "Latitude"
+        );
+    }
+
+    #[test]
+    fn table_display_name_uses_title_case_heuristic() {
+        assert_eq!(
+            display_name_table("vehicles_log", &DisplayConfig::default()),
+            "Vehicles Log"
+        );
+    }
+
+    #[test]
+    fn table_display_name_prefers_override() {
+        let config = AppConfig::parse(FULL_CONFIG).expect("full config should parse");
+
+        assert_eq!(
+            display_name_table("vehicles_log", &config.display),
+            "Fleet Log"
+        );
+    }
+
+    #[test]
+    fn example_config_parses() {
+        let config =
+            AppConfig::parse(include_str!("../seeki.toml.example")).expect("example config parses");
+
+        assert!(config.tables.include.is_some());
+        assert!(!config.display.tables.is_empty());
+        assert!(!config.display.columns.is_empty());
+        assert_eq!(config.branding.title.as_deref(), Some("AutoConnect"));
+        assert_eq!(config.branding.subtitle.as_deref(), Some("Fleet Telemetry"));
+        assert_eq!(
+            config
+                .display
+                .columns
+                .get("vehicles_log")
+                .and_then(|c| c.get("posn_lat"))
+                .map(String::as_str),
+            Some("Latitude")
+        );
+    }
+
+    #[test]
+    fn casualify_preserves_all_caps_segments() {
+        assert_eq!(
+            display_name_column("t", "GPS_LATITUDE", &DisplayConfig::default()),
+            "GPS LATITUDE"
+        );
+    }
+
+    #[test]
+    fn casualify_preserves_mixed_caps_segments() {
+        assert_eq!(
+            display_name_table("HTTP_STATUS", &DisplayConfig::default()),
+            "HTTP STATUS"
+        );
+    }
+
+    #[test]
+    fn casualify_handles_id_only_column() {
+        // "_id" with drop_id_suffix strips to "" — fallback returns raw name
+        assert_eq!(
+            display_name_column("t", "_id", &DisplayConfig::default()),
+            "_id"
+        );
+    }
+
+    #[test]
+    fn casualify_handles_bare_id_column() {
+        assert_eq!(
+            display_name_column("t", "id", &DisplayConfig::default()),
+            "Id"
+        );
+    }
+
+    #[test]
+    fn casualify_handles_empty_string() {
+        assert_eq!(
+            display_name_column("t", "", &DisplayConfig::default()),
+            ""
+        );
+    }
+
+    #[test]
+    fn casualify_handles_numbers_in_name() {
+        assert_eq!(
+            display_name_table("vehicle_v2_data", &DisplayConfig::default()),
+            "Vehicle V2 Data"
+        );
+    }
+
+    fn effective_tables<'a>(config: &TablesConfig, tables: &'a [&'a str]) -> Vec<&'a str> {
+        tables
+            .iter()
+            .copied()
+            .filter(|table| config.allows(table))
+            .collect()
+    }
+
+    fn load_config(content: &str) -> AppConfig {
+        let _guard = cwd_lock().lock().expect("cwd lock should not be poisoned");
+        let _temp_dir = TempConfigDir::new(content);
+
+        AppConfig::load().expect("config should load")
+    }
+
+    fn cwd_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    struct TempConfigDir {
+        original_dir: PathBuf,
+        temp_dir: PathBuf,
+    }
+
+    impl TempConfigDir {
+        fn new(content: &str) -> Self {
+            let original_dir = std::env::current_dir().expect("current dir should exist");
+            let temp_dir = std::env::temp_dir().join(format!(
+                "seeki-config-test-{}-{}",
+                std::process::id(),
+                SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .expect("system time should be after epoch")
+                    .as_nanos()
+            ));
+
+            fs::create_dir_all(&temp_dir).expect("temp dir should be created");
+            fs::write(temp_dir.join("seeki.toml"), content).expect("temp config should be written");
+            std::env::set_current_dir(&temp_dir).expect("cwd should switch to temp dir");
+
+            Self {
+                original_dir,
+                temp_dir,
+            }
+        }
+    }
+
+    impl Drop for TempConfigDir {
+        fn drop(&mut self) {
+            std::env::set_current_dir(&self.original_dir).expect("cwd should be restored");
+            fs::remove_dir_all(&self.temp_dir).expect("temp dir should be removed");
+        }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -165,7 +165,7 @@ impl AppConfig {
         Ok(config)
     }
 
-    fn parse(content: &str) -> anyhow::Result<Self> {
+    pub fn parse(content: &str) -> anyhow::Result<Self> {
         Ok(toml::from_str(content)?)
     }
 

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,7 +1,22 @@
-mod postgres;
+pub mod postgres;
+
+use std::collections::HashMap;
 
 use crate::config::{DatabaseConfig, DatabaseKind};
 use serde::Serialize;
+
+/// Client-facing validation error (e.g. invalid column name in filter).
+/// The API layer maps this to HTTP 400.
+#[derive(Debug)]
+pub struct ValidationError(pub String);
+
+impl std::fmt::Display for ValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::error::Error for ValidationError {}
 
 #[derive(Debug, Serialize)]
 pub struct TableInfo {
@@ -25,6 +40,17 @@ pub struct QueryResult {
     pub total_rows: i64,
     pub page: u32,
     pub page_size: u32,
+}
+
+/// Bundled parameters for querying rows from a table.
+pub struct RowQueryParams<'a> {
+    pub table: &'a str,
+    pub page: u32,
+    pub page_size: u32,
+    pub sort_column: Option<&'a str>,
+    pub sort_direction: Option<&'a str>,
+    pub search: Option<&'a str>,
+    pub filters: &'a HashMap<String, String>,
 }
 
 pub enum DatabasePool {
@@ -59,19 +85,9 @@ impl DatabasePool {
         }
     }
 
-    pub async fn query_rows(
-        &self,
-        table: &str,
-        page: u32,
-        page_size: u32,
-        sort_column: Option<&str>,
-        sort_direction: Option<&str>,
-        search: Option<&str>,
-    ) -> anyhow::Result<QueryResult> {
+    pub async fn query_rows(&self, params: &RowQueryParams<'_>) -> anyhow::Result<QueryResult> {
         match self {
-            Self::Postgres(pool) => {
-                postgres::query_rows(pool, table, page, page_size, sort_column, sort_direction, search).await
-            }
+            Self::Postgres(pool) => postgres::query_rows(pool, params).await,
         }
     }
 }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -21,7 +21,7 @@ impl std::error::Error for ValidationError {}
 #[derive(Debug, Serialize)]
 pub struct TableInfo {
     pub name: String,
-    pub row_count_estimate: i64,
+    pub row_count_estimate: Option<i64>,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -53,6 +53,15 @@ pub struct RowQueryParams<'a> {
     pub filters: &'a HashMap<String, String>,
 }
 
+/// Parameters for CSV export (no pagination).
+pub struct ExportQueryParams<'a> {
+    pub table: &'a str,
+    pub sort_column: Option<&'a str>,
+    pub sort_direction: Option<&'a str>,
+    pub search: Option<&'a str>,
+    pub filters: &'a HashMap<String, String>,
+}
+
 pub enum DatabasePool {
     Postgres(sqlx::PgPool),
 }
@@ -88,6 +97,14 @@ impl DatabasePool {
     pub async fn query_rows(&self, params: &RowQueryParams<'_>) -> anyhow::Result<QueryResult> {
         match self {
             Self::Postgres(pool) => postgres::query_rows(pool, params).await,
+        }
+    }
+
+    /// Get a reference to the underlying PostgreSQL pool for streaming operations.
+    /// Returns None if the pool is not PostgreSQL.
+    pub fn pg_pool(&self) -> Option<&sqlx::PgPool> {
+        match self {
+            Self::Postgres(pool) => Some(pool),
         }
     }
 }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -24,7 +24,7 @@ pub struct TableInfo {
     pub row_count_estimate: i64,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct ColumnInfo {
     pub name: String,
     pub data_type: String,
@@ -91,6 +91,15 @@ impl DatabasePool {
     pub async fn get_columns(&self, table: &str) -> anyhow::Result<Vec<ColumnInfo>> {
         match self {
             Self::Postgres(pool) => postgres::get_columns(pool, table).await,
+        }
+    }
+
+    pub async fn get_columns_bulk(
+        &self,
+        tables: &[&str],
+    ) -> anyhow::Result<std::collections::HashMap<String, Vec<ColumnInfo>>> {
+        match self {
+            Self::Postgres(pool) => postgres::get_columns_bulk(pool, tables).await,
         }
     }
 

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -284,7 +284,7 @@ pub async fn query_rows(
     }
     let total_rows: i64 = count_query.fetch_one(pool).await?.get("cnt");
 
-    let offset = (params.page.saturating_sub(1)) * params.page_size;
+    let offset = (params.page.saturating_sub(1) as u64) * (params.page_size as u64);
     let query_sql = format!(
         "SELECT * FROM \"{table}\" {} {} LIMIT {} OFFSET {offset}",
         qb.where_clause, qb.order_clause, params.page_size

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -1,6 +1,8 @@
+use std::collections::HashMap;
+use std::pin::Pin;
+
 use futures::Stream;
 use sqlx::{PgPool, Row, postgres::PgPoolOptions};
-use std::pin::Pin;
 
 use super::{ColumnInfo, ExportQueryParams, QueryResult, RowQueryParams, TableInfo, ValidationError};
 
@@ -100,6 +102,62 @@ pub async fn get_columns(pool: &PgPool, table: &str) -> anyhow::Result<Vec<Colum
     Ok(columns)
 }
 
+/// Get column metadata for multiple tables in a single query.
+/// Returns a map from table name to its columns.
+pub async fn get_columns_bulk(
+    pool: &PgPool,
+    tables: &[&str],
+) -> anyhow::Result<HashMap<String, Vec<ColumnInfo>>> {
+    if tables.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    // Build a parameterized ANY($1) query using a text array
+    let rows = sqlx::query(
+        r#"
+        SELECT
+            c.table_name,
+            c.column_name,
+            c.data_type,
+            c.udt_name,
+            c.is_nullable,
+            CASE WHEN pk.column_name IS NOT NULL THEN true ELSE false END AS is_pk
+        FROM information_schema.columns c
+        LEFT JOIN (
+            SELECT tc.table_name, kcu.column_name
+            FROM information_schema.table_constraints tc
+            JOIN information_schema.key_column_usage kcu
+                ON tc.constraint_name = kcu.constraint_name
+            WHERE tc.table_name = ANY($1)
+              AND tc.constraint_type = 'PRIMARY KEY'
+        ) pk ON pk.table_name = c.table_name AND pk.column_name = c.column_name
+        WHERE c.table_schema = 'public'
+          AND c.table_name = ANY($1)
+        ORDER BY c.table_name, c.ordinal_position
+        "#,
+    )
+    .bind(tables)
+    .fetch_all(pool)
+    .await?;
+
+    let mut result: HashMap<String, Vec<ColumnInfo>> = HashMap::new();
+    for r in &rows {
+        let table_name: String = r.get("table_name");
+        let udt: String = r.get("udt_name");
+        let data_type: String = r.get("data_type");
+        let col = ColumnInfo {
+            name: r.get("column_name"),
+            display_type: humanize_type(&data_type, &udt),
+            data_type,
+            is_nullable: r.get::<String, _>("is_nullable") == "YES",
+            is_primary_key: r.get("is_pk"),
+        };
+        result.entry(table_name).or_default().push(col);
+    }
+
+    Ok(result)
+}
+
 /// Validate that a name contains only alphanumeric characters and underscores.
 fn is_valid_identifier(name: &str) -> bool {
     !name.is_empty() && name.chars().all(|c| c.is_alphanumeric() || c == '_')
@@ -170,7 +228,10 @@ fn build_query_clauses(
 
     let order_clause = if let Some(col) = sort_column {
         if !is_valid_identifier(col) {
-            anyhow::bail!("Invalid sort column name");
+            return Err(ValidationError(format!("Invalid sort column name: {col}")).into());
+        }
+        if !valid_column_names.contains(col) {
+            return Err(ValidationError(format!("Unknown sort column: {col}")).into());
         }
         let dir = match sort_direction {
             Some("desc" | "DESC") => "DESC",
@@ -301,14 +362,25 @@ pub async fn export_rows_stream<'a>(
 fn pg_value_to_json(row: &sqlx::postgres::PgRow, col: &str, data_type: &str) -> serde_json::Value {
     use serde_json::Value;
 
-    // Try to extract based on type, falling back to string representation
     match data_type {
-        "integer" | "smallint" | "bigint" => row
+        "smallint" => row
+            .try_get::<i16, _>(col)
+            .map(|v| Value::from(v as i64))
+            .unwrap_or(Value::Null),
+        "integer" => row
+            .try_get::<i32, _>(col)
+            .map(|v| Value::from(v as i64))
+            .unwrap_or(Value::Null),
+        "bigint" => row
             .try_get::<i64, _>(col)
             .map(Value::from)
             .unwrap_or(Value::Null),
-        "real" | "double precision" | "numeric" => row
+        "real" | "double precision" => row
             .try_get::<f64, _>(col)
+            .map(Value::from)
+            .unwrap_or(Value::Null),
+        "numeric" => row
+            .try_get::<String, _>(col)
             .map(Value::from)
             .unwrap_or(Value::Null),
         "boolean" => row

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -1,6 +1,28 @@
-use sqlx::{PgPool, Row};
+use sqlx::{PgPool, Row, postgres::PgPoolOptions};
 
-use super::{ColumnInfo, QueryResult, TableInfo};
+use super::{ColumnInfo, QueryResult, RowQueryParams, TableInfo, ValidationError};
+
+/// Test a PostgreSQL connection and return the list of public table names.
+/// Opens a temporary pool, queries table names, then closes it.
+pub async fn test_connection(url: &str) -> anyhow::Result<Vec<String>> {
+    let pool = PgPoolOptions::new()
+        .max_connections(1)
+        .acquire_timeout(std::time::Duration::from_secs(10))
+        .connect(url)
+        .await?;
+
+    let rows = sqlx::query(
+        "SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' ORDER BY table_name",
+    )
+    .fetch_all(&pool)
+    .await?;
+
+    let tables: Vec<String> = rows.iter().map(|r| r.get("table_name")).collect();
+
+    pool.close().await;
+
+    Ok(tables)
+}
 
 /// List all user tables in the public schema with estimated row counts.
 pub async fn list_tables(pool: &PgPool) -> anyhow::Result<Vec<TableInfo>> {
@@ -76,62 +98,93 @@ pub async fn get_columns(pool: &PgPool, table: &str) -> anyhow::Result<Vec<Colum
     Ok(columns)
 }
 
-/// Query paginated rows from a table with optional sort and search.
+/// Validate that a name contains only alphanumeric characters and underscores.
+fn is_valid_identifier(name: &str) -> bool {
+    !name.is_empty() && name.chars().all(|c| c.is_alphanumeric() || c == '_')
+}
+
+/// Query paginated rows from a table with optional sort, search, and per-column filters.
 pub async fn query_rows(
     pool: &PgPool,
-    table: &str,
-    page: u32,
-    page_size: u32,
-    sort_column: Option<&str>,
-    sort_direction: Option<&str>,
-    search: Option<&str>,
+    params: &RowQueryParams<'_>,
 ) -> anyhow::Result<QueryResult> {
+    let table = params.table;
+    let page = params.page;
+    let page_size = params.page_size;
+    let sort_column = params.sort_column;
+    let sort_direction = params.sort_direction;
+    let search = params.search;
+    let filters = params.filters;
+
     // Validate table name (prevent SQL injection — only allow alphanumeric + underscore)
-    if !table.chars().all(|c| c.is_alphanumeric() || c == '_') {
+    if !is_valid_identifier(table) {
         anyhow::bail!("Invalid table name");
     }
 
     let columns = get_columns(pool, table).await?;
 
-    // Build WHERE clause for search
-    let where_clause = if let Some(term) = search {
-        if term.is_empty() {
-            String::new()
-        } else {
-            let text_cols: Vec<String> = columns
-                .iter()
-                .filter(|c| is_text_type(&c.data_type))
-                .map(|c| format!("\"{}\"::text ILIKE '%' || $1 || '%'", c.name))
-                .collect();
+    // Validate filter column names against the actual schema
+    let valid_column_names: std::collections::HashSet<&str> =
+        columns.iter().map(|c| c.name.as_str()).collect();
 
-            if text_cols.is_empty() {
-                String::new()
-            } else {
-                format!("WHERE {}", text_cols.join(" OR "))
-            }
+    for col_name in filters.keys() {
+        if !is_valid_identifier(col_name) {
+            return Err(ValidationError(format!("Invalid filter column name: {col_name}")).into());
         }
-    } else {
+        if !valid_column_names.contains(col_name.as_str()) {
+            return Err(ValidationError(format!("Unknown filter column: {col_name}")).into());
+        }
+    }
+
+    // Build WHERE conditions with tracked bind parameters
+    let mut conditions: Vec<String> = Vec::new();
+    let mut bind_values: Vec<String> = Vec::new();
+    let mut param_idx: u32 = 1;
+
+    // Search condition (searches across all text columns)
+    let has_search = search.is_some_and(|s| !s.is_empty());
+    if has_search {
+        let text_cols: Vec<String> = columns
+            .iter()
+            .filter(|c| is_text_type(&c.data_type))
+            .map(|c| format!("\"{}\"::text ILIKE '%' || ${param_idx} || '%'", c.name))
+            .collect();
+
+        if !text_cols.is_empty() {
+            conditions.push(format!("({})", text_cols.join(" OR ")));
+            bind_values.push(search.unwrap().to_string());
+            param_idx += 1;
+        }
+    }
+
+    // Per-column filter conditions (AND-ed, ILIKE with %value%)
+    // Sort by key for deterministic parameter ordering
+    let mut filter_entries: Vec<_> = filters.iter().collect();
+    filter_entries.sort_by_key(|(k, _)| k.as_str());
+
+    for (col_name, value) in &filter_entries {
+        conditions.push(format!("\"{}\"::text ILIKE ${param_idx}", col_name));
+        bind_values.push(format!("%{value}%"));
+        param_idx += 1;
+    }
+
+    let where_clause = if conditions.is_empty() {
         String::new()
+    } else {
+        format!("WHERE {}", conditions.join(" AND "))
     };
 
     // Count total matching rows
     let count_sql = format!("SELECT COUNT(*) as cnt FROM \"{table}\" {where_clause}");
-    let total_rows: i64 = if search.is_some_and(|s| !s.is_empty()) {
-        sqlx::query(&count_sql)
-            .bind(search.unwrap_or_default())
-            .fetch_one(pool)
-            .await?
-            .get("cnt")
-    } else {
-        sqlx::query(&format!("SELECT COUNT(*) as cnt FROM \"{table}\""))
-            .fetch_one(pool)
-            .await?
-            .get("cnt")
-    };
+    let mut count_query = sqlx::query(&count_sql);
+    for val in &bind_values {
+        count_query = count_query.bind(val);
+    }
+    let total_rows: i64 = count_query.fetch_one(pool).await?.get("cnt");
 
     // Build ORDER BY
     let order_clause = if let Some(col) = sort_column {
-        if !col.chars().all(|c| c.is_alphanumeric() || c == '_') {
+        if !is_valid_identifier(col) {
             anyhow::bail!("Invalid sort column name");
         }
         let dir = match sort_direction {
@@ -148,14 +201,11 @@ pub async fn query_rows(
         "SELECT * FROM \"{table}\" {where_clause} {order_clause} LIMIT {page_size} OFFSET {offset}"
     );
 
-    let rows = if search.is_some_and(|s| !s.is_empty()) {
-        sqlx::query(&query_sql)
-            .bind(search.unwrap_or_default())
-            .fetch_all(pool)
-            .await?
-    } else {
-        sqlx::query(&query_sql).fetch_all(pool).await?
-    };
+    let mut data_query = sqlx::query(&query_sql);
+    for val in &bind_values {
+        data_query = data_query.bind(val);
+    }
+    let rows = data_query.fetch_all(pool).await?;
 
     // Convert rows to JSON values
     let json_rows: Vec<serde_json::Value> = rows
@@ -217,7 +267,11 @@ fn humanize_type(data_type: &str, _udt: &str) -> String {
         "date" => "Date".to_string(),
         "timestamp without time zone" | "timestamp with time zone" => "Date & Time".to_string(),
         "json" | "jsonb" => "JSON".to_string(),
+        "time without time zone" | "time with time zone" => "Time".to_string(),
+        "interval" => "Duration".to_string(),
         "uuid" => "UUID".to_string(),
+        "inet" | "cidr" => "Network".to_string(),
+        "money" => "Currency".to_string(),
         "bytea" => "Binary".to_string(),
         "ARRAY" => "List".to_string(),
         other => other.to_string(),
@@ -229,4 +283,43 @@ fn is_text_type(data_type: &str) -> bool {
         data_type,
         "character varying" | "character" | "text" | "uuid"
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_identifier_accepts_alphanumeric_underscore() {
+        assert!(is_valid_identifier("vehicle_id"));
+        assert!(is_valid_identifier("col1"));
+        assert!(is_valid_identifier("_private"));
+        assert!(is_valid_identifier("CamelCase"));
+    }
+
+    #[test]
+    fn valid_identifier_rejects_special_chars() {
+        assert!(!is_valid_identifier("col-name"));
+        assert!(!is_valid_identifier("col.name"));
+        assert!(!is_valid_identifier("col name"));
+        assert!(!is_valid_identifier("col;DROP TABLE"));
+        assert!(!is_valid_identifier(""));
+    }
+
+    #[test]
+    fn humanize_type_maps_common_types() {
+        assert_eq!(humanize_type("character varying", "varchar"), "Text");
+        assert_eq!(humanize_type("integer", "int4"), "Number");
+        assert_eq!(humanize_type("boolean", "bool"), "Yes/No");
+        assert_eq!(humanize_type("timestamp with time zone", "timestamptz"), "Date & Time");
+    }
+
+    #[test]
+    fn is_text_type_identifies_text_columns() {
+        assert!(is_text_type("character varying"));
+        assert!(is_text_type("text"));
+        assert!(is_text_type("uuid"));
+        assert!(!is_text_type("integer"));
+        assert!(!is_text_type("boolean"));
+    }
 }

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -1,6 +1,8 @@
+use futures::Stream;
 use sqlx::{PgPool, Row, postgres::PgPoolOptions};
+use std::pin::Pin;
 
-use super::{ColumnInfo, QueryResult, RowQueryParams, TableInfo, ValidationError};
+use super::{ColumnInfo, ExportQueryParams, QueryResult, RowQueryParams, TableInfo, ValidationError};
 
 /// Test a PostgreSQL connection and return the list of public table names.
 /// Opens a temporary pool, queries table names, then closes it.
@@ -103,26 +105,20 @@ fn is_valid_identifier(name: &str) -> bool {
     !name.is_empty() && name.chars().all(|c| c.is_alphanumeric() || c == '_')
 }
 
-/// Query paginated rows from a table with optional sort, search, and per-column filters.
-pub async fn query_rows(
-    pool: &PgPool,
-    params: &RowQueryParams<'_>,
-) -> anyhow::Result<QueryResult> {
-    let table = params.table;
-    let page = params.page;
-    let page_size = params.page_size;
-    let sort_column = params.sort_column;
-    let sort_direction = params.sort_direction;
-    let search = params.search;
-    let filters = params.filters;
+/// Shared WHERE clause and bind values builder for query_rows and export.
+struct QueryBuilder {
+    where_clause: String,
+    order_clause: String,
+    bind_values: Vec<String>,
+}
 
-    // Validate table name (prevent SQL injection — only allow alphanumeric + underscore)
-    if !is_valid_identifier(table) {
-        anyhow::bail!("Invalid table name");
-    }
-
-    let columns = get_columns(pool, table).await?;
-
+fn build_query_clauses(
+    columns: &[ColumnInfo],
+    search: Option<&str>,
+    filters: &std::collections::HashMap<String, String>,
+    sort_column: Option<&str>,
+    sort_direction: Option<&str>,
+) -> anyhow::Result<QueryBuilder> {
     // Validate filter column names against the actual schema
     let valid_column_names: std::collections::HashSet<&str> =
         columns.iter().map(|c| c.name.as_str()).collect();
@@ -136,7 +132,6 @@ pub async fn query_rows(
         }
     }
 
-    // Build WHERE conditions with tracked bind parameters
     let mut conditions: Vec<String> = Vec::new();
     let mut bind_values: Vec<String> = Vec::new();
     let mut param_idx: u32 = 1;
@@ -158,7 +153,6 @@ pub async fn query_rows(
     }
 
     // Per-column filter conditions (AND-ed, ILIKE with %value%)
-    // Sort by key for deterministic parameter ordering
     let mut filter_entries: Vec<_> = filters.iter().collect();
     filter_entries.sort_by_key(|(k, _)| k.as_str());
 
@@ -174,15 +168,6 @@ pub async fn query_rows(
         format!("WHERE {}", conditions.join(" AND "))
     };
 
-    // Count total matching rows
-    let count_sql = format!("SELECT COUNT(*) as cnt FROM \"{table}\" {where_clause}");
-    let mut count_query = sqlx::query(&count_sql);
-    for val in &bind_values {
-        count_query = count_query.bind(val);
-    }
-    let total_rows: i64 = count_query.fetch_one(pool).await?.get("cnt");
-
-    // Build ORDER BY
     let order_clause = if let Some(col) = sort_column {
         if !is_valid_identifier(col) {
             anyhow::bail!("Invalid sort column name");
@@ -196,18 +181,53 @@ pub async fn query_rows(
         String::new()
     };
 
-    let offset = (page.saturating_sub(1)) * page_size;
+    Ok(QueryBuilder {
+        where_clause,
+        order_clause,
+        bind_values,
+    })
+}
+
+/// Query paginated rows from a table with optional sort, search, and per-column filters.
+pub async fn query_rows(
+    pool: &PgPool,
+    params: &RowQueryParams<'_>,
+) -> anyhow::Result<QueryResult> {
+    let table = params.table;
+
+    if !is_valid_identifier(table) {
+        anyhow::bail!("Invalid table name");
+    }
+
+    let columns = get_columns(pool, table).await?;
+    let qb = build_query_clauses(
+        &columns,
+        params.search,
+        params.filters,
+        params.sort_column,
+        params.sort_direction,
+    )?;
+
+    // Count total matching rows
+    let count_sql = format!("SELECT COUNT(*) as cnt FROM \"{table}\" {}", qb.where_clause);
+    let mut count_query = sqlx::query(&count_sql);
+    for val in &qb.bind_values {
+        count_query = count_query.bind(val);
+    }
+    let total_rows: i64 = count_query.fetch_one(pool).await?.get("cnt");
+
+    let offset = (params.page.saturating_sub(1)) * params.page_size;
     let query_sql = format!(
-        "SELECT * FROM \"{table}\" {where_clause} {order_clause} LIMIT {page_size} OFFSET {offset}"
+        "SELECT * FROM \"{table}\" {} {} LIMIT {} OFFSET {offset}",
+        qb.where_clause, qb.order_clause, params.page_size
     );
 
     let mut data_query = sqlx::query(&query_sql);
-    for val in &bind_values {
+    for val in &qb.bind_values {
         data_query = data_query.bind(val);
     }
     let rows = data_query.fetch_all(pool).await?;
 
-    // Convert rows to JSON values
     let json_rows: Vec<serde_json::Value> = rows
         .iter()
         .map(|row| {
@@ -224,9 +244,57 @@ pub async fn query_rows(
         columns,
         rows: json_rows,
         total_rows,
-        page,
-        page_size,
+        page: params.page,
+        page_size: params.page_size,
     })
+}
+
+/// Build a streaming query for CSV export — returns all matching rows without pagination.
+/// The returned stream yields `Result<PgRow>` items for incremental processing.
+pub async fn export_rows_stream<'a>(
+    pool: &'a PgPool,
+    params: &'a ExportQueryParams<'a>,
+) -> anyhow::Result<(
+    Vec<ColumnInfo>,
+    Pin<Box<dyn Stream<Item = Result<sqlx::postgres::PgRow, sqlx::Error>> + Send + 'a>>,
+)> {
+    let table = params.table;
+
+    if !is_valid_identifier(table) {
+        anyhow::bail!("Invalid table name");
+    }
+
+    let columns = get_columns(pool, table).await?;
+    let qb = build_query_clauses(
+        &columns,
+        params.search,
+        params.filters,
+        params.sort_column,
+        params.sort_direction,
+    )?;
+
+    let query_sql = format!(
+        "SELECT * FROM \"{table}\" {} {}",
+        qb.where_clause, qb.order_clause
+    );
+
+    // We need to own the bind values so the stream can reference them.
+    // Use a channel-based approach: build the query with owned values.
+    let bind_values = qb.bind_values;
+
+    let stream = async_stream::stream! {
+        let mut query = sqlx::query(&query_sql);
+        for val in &bind_values {
+            query = query.bind(val);
+        }
+        use futures::StreamExt;
+        let mut row_stream = query.fetch(pool);
+        while let Some(row) = row_stream.next().await {
+            yield row;
+        }
+    };
+
+    Ok((columns, Box::pin(stream)))
 }
 
 /// Convert a PostgreSQL column value to a serde_json::Value.

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -47,9 +47,16 @@ pub async fn list_tables(pool: &PgPool) -> anyhow::Result<Vec<TableInfo>> {
 
     let tables = rows
         .iter()
-        .map(|r| TableInfo {
-            name: r.get("table_name"),
-            row_count_estimate: r.get("row_estimate"),
+        .map(|r| {
+            let raw_estimate: i64 = r.get("row_estimate");
+            TableInfo {
+                name: r.get("table_name"),
+                row_count_estimate: if raw_estimate < 0 {
+                    None
+                } else {
+                    Some(raw_estimate)
+                },
+            }
         })
         .collect();
 

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -191,7 +191,7 @@ fn pg_value_to_json(row: &sqlx::postgres::PgRow, col: &str, data_type: &str) -> 
             .unwrap_or(Value::Null),
         "real" | "double precision" | "numeric" => row
             .try_get::<f64, _>(col)
-            .map(|v| Value::from(v))
+            .map(Value::from)
             .unwrap_or(Value::Null),
         "boolean" => row
             .try_get::<bool, _>(col)

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,14 +2,16 @@ mod api;
 mod auth;
 mod config;
 mod db;
+#[cfg(test)]
+mod testutil;
 
 use std::sync::Arc;
 
 use axum::Router;
-use tower_http::cors::CorsLayer;
+use tower_http::cors::{AllowOrigin, CorsLayer};
 use tracing_subscriber::EnvFilter;
 
-use crate::config::AppConfig;
+use crate::config::{AppConfig, ConfigLoadError};
 use crate::db::DatabasePool;
 
 pub struct AppState {
@@ -25,8 +27,32 @@ async fn main() -> anyhow::Result<()> {
 
     match AppConfig::load() {
         Ok(config) => start_normal(config).await,
-        Err(_) => start_setup_mode().await,
+        Err(ConfigLoadError::NotFound) => start_setup_mode().await,
+        Err(ConfigLoadError::Invalid { path, source }) => {
+            tracing::error!(
+                "Config file at {} is invalid: {source}",
+                path.display()
+            );
+            tracing::error!("Fix the config file or delete it to enter setup mode");
+            anyhow::bail!("Invalid config at {}: {source}", path.display())
+        }
     }
+}
+
+/// Build a CORS layer that only allows localhost origins.
+fn localhost_cors() -> CorsLayer {
+    CorsLayer::new()
+        .allow_origin(AllowOrigin::predicate(|origin, _| {
+            if let Ok(s) = origin.to_str() {
+                s.starts_with("http://localhost")
+                    || s.starts_with("http://127.0.0.1")
+                    || s.starts_with("http://[::1]")
+            } else {
+                false
+            }
+        }))
+        .allow_methods(tower_http::cors::Any)
+        .allow_headers(tower_http::cors::Any)
 }
 
 /// Normal mode: config exists, connect to DB and serve full API.
@@ -42,7 +68,7 @@ async fn start_normal(config: AppConfig) -> anyhow::Result<()> {
 
     let app = Router::new()
         .nest("/api", api::router())
-        .layer(CorsLayer::permissive())
+        .layer(localhost_cors())
         .with_state(state);
 
     let listener = tokio::net::TcpListener::bind(&bind_addr).await?;
@@ -60,7 +86,7 @@ async fn start_setup_mode() -> anyhow::Result<()> {
 
     let app = Router::new()
         .nest("/api", api::setup::router())
-        .layer(CorsLayer::permissive());
+        .layer(localhost_cors());
 
     let listener = tokio::net::TcpListener::bind(bind_addr).await?;
     tracing::info!("SeeKi setup wizard listening on http://{bind_addr}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ async fn main() -> anyhow::Result<()> {
         .init();
 
     let config = AppConfig::load()?;
+    config.tables.warn_overlaps();
     let bind_addr = format!("{}:{}", config.server.host, config.server.port);
 
     tracing::info!("Connecting to database...");

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,9 +44,12 @@ fn localhost_cors() -> CorsLayer {
     CorsLayer::new()
         .allow_origin(AllowOrigin::predicate(|origin, _| {
             if let Ok(s) = origin.to_str() {
-                s.starts_with("http://localhost")
-                    || s.starts_with("http://127.0.0.1")
-                    || s.starts_with("http://[::1]")
+                s == "http://localhost"
+                    || s.starts_with("http://localhost:")
+                    || s == "http://127.0.0.1"
+                    || s.starts_with("http://127.0.0.1:")
+                    || s == "http://[::1]"
+                    || s.starts_with("http://[::1]:")
             } else {
                 false
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,14 @@ async fn main() -> anyhow::Result<()> {
         .with_env_filter(EnvFilter::from_default_env().add_directive("seeki=info".parse()?))
         .init();
 
-    let config = AppConfig::load()?;
+    match AppConfig::load() {
+        Ok(config) => start_normal(config).await,
+        Err(_) => start_setup_mode().await,
+    }
+}
+
+/// Normal mode: config exists, connect to DB and serve full API.
+async fn start_normal(config: AppConfig) -> anyhow::Result<()> {
     config.tables.warn_overlaps();
     let bind_addr = format!("{}:{}", config.server.host, config.server.port);
 
@@ -40,6 +47,24 @@ async fn main() -> anyhow::Result<()> {
 
     let listener = tokio::net::TcpListener::bind(&bind_addr).await?;
     tracing::info!("SeeKi listening on http://{bind_addr}");
+    axum::serve(listener, app).await?;
+
+    Ok(())
+}
+
+/// Setup mode: no config found, serve only setup wizard endpoints.
+async fn start_setup_mode() -> anyhow::Result<()> {
+    let bind_addr = "127.0.0.1:3141";
+
+    tracing::info!("No config file found — starting in setup mode");
+
+    let app = Router::new()
+        .nest("/api", api::setup::router())
+        .layer(CorsLayer::permissive());
+
+    let listener = tokio::net::TcpListener::bind(bind_addr).await?;
+    tracing::info!("SeeKi setup wizard listening on http://{bind_addr}");
+    tracing::info!("Configure your database connection, then restart the app");
     axum::serve(listener, app).await?;
 
     Ok(())

--- a/src/testutil.rs
+++ b/src/testutil.rs
@@ -1,0 +1,11 @@
+/// Shared test utilities to prevent CWD races between test modules.
+///
+/// Both `config::tests` and `api::setup::tests` change the process working directory,
+/// which is global state. This single mutex serializes all such tests across modules.
+
+use std::sync::{Mutex, OnceLock};
+
+pub fn cwd_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}


### PR DESCRIPTION
## Summary
- Config extensions: add [tables], [display.columns], [branding] sections to AppConfig with sensible defaults
- Per-column filter support: filter.{column}=value query params with schema validation and parameterized ILIKE
- Display config endpoint: GET /api/config/display with standalone casualification utility
- CSV export endpoint: GET /api/export/{table}/csv using SQLx cursor streaming for 500K+ row tables
- Setup wizard endpoints: two-mode server (setup-only vs normal), test-connection and save endpoints
- Table include/exclude filtering: both include and exclude allowed (include first, then subtract exclude)
- Cross-cutting: thiserror-based AppError enum (400/404/500)

## Spec
See `backend-api-config-spec.md` in the branch root for full acceptance criteria, technical plan, and task breakdown.

## Sub-issues
- #7 Config extensions (T1)
- #8 Per-column filter support (T2)
- #9 Display config endpoint (T3)
- #10 CSV export endpoint (T4)
- #11 Setup wizard backend endpoints (T5)
- #12 Table include/exclude filtering (T6)

## Test plan
- [ ] Missing config sections parse with defaults -- app boots with minimal seeki.toml
- [ ] Include + exclude coexist: include applied first, then exclude subtracted
- [ ] Single per-column filter returns matching rows only
- [ ] Multiple filters AND together correctly
- [ ] Invalid column name in filter returns 400
- [ ] SQL injection via filter values is prevented (parameterized queries)
- [ ] GET /api/config/display returns correct JSON shape with casualified names
- [ ] Config override takes precedence over auto-heuristic
- [ ] CSV export streams with display name headers and Content-Disposition
- [ ] CSV export of 500K+ row table completes without OOM
- [ ] POST /api/setup/test-connection with valid URL returns success + table list
- [ ] POST /api/setup/test-connection with invalid URL returns descriptive error
- [ ] POST /api/setup/save writes parseable seeki.toml with comments
- [ ] Server boots in setup-only mode when no config exists
- [ ] Server boots in normal mode when config exists
- [ ] Table list respects include/exclude config
- [ ] Bad requests return 400, not-found returns 404, internal errors return 500

Closes #1