### PR TITLE
epic: Data Grid & Table Navigation

### DIFF
--- a/.council/council-result.json
+++ b/.council/council-result.json
@@ -1,45 +1,40 @@
 {
   "motion": "Merge PR #29: epic: Data Grid & Table Navigation",
-  "verdict": "CONDITIONAL",
+  "verdict": "FOR",
   "date": "2026-04-09",
-  "rounds": 3,
-  "agents": {
-    "advocate-1": "CONDITIONAL",
-    "advocate-2": "CONDITIONAL",
-    "critic-1": "CONDITIONAL",
-    "critic-2": "CONDITIONAL",
-    "questioner": "2 bugs confirmed, 0 unsubstantiated"
+  "council": {
+    "advocates": 1,
+    "critics": 1,
+    "questioner": 0,
+    "rounds": 2,
+    "mode": "1v1-no-questioner",
+    "session": 2,
+    "note": "Session 2: post-fix review. All pre-merge findings from sessions 1+2 resolved. No new pre-merge blockers."
   },
   "findings": [
     {
       "id": 1,
-      "description": "Date off-by-one for non-UTC users: new Date() on bare date string parses as UTC midnight, rendered in local timezone shows wrong day. Also shows spurious time components for date-only fields.",
+      "description": "Date off-by-one for non-UTC users: new Date() on bare date string parses as UTC midnight, shows wrong day west of UTC.",
       "file": "frontend/src/lib/data-grid.ts",
-      "line": 111,
+      "line": 116,
       "type": "bug",
       "severity": "high",
       "verified": true,
-      "conceded_by": ["advocate-1", "advocate-2"],
-      "fix_description": "Detect date-only columns (column.data_type === 'date') and either append 'T00:00:00' for local parsing or use a separate date-only formatter without time components.",
-      "citations": [
-        "frontend/src/lib/data-grid.ts:111",
-        "frontend/src/lib/data-grid.ts:18-23",
-        "src/db/postgres.rs:408-411"
-      ]
+      "conceded_by": ["advocate-1"],
+      "status": "FIXED",
+      "session": 1
     },
     {
       "id": 2,
-      "description": "Timestamp formatter omits year: multi-year records display identically (e.g. 'Jan 15, 3:45 PM' for both 2023 and 2024). Year only visible in tooltip.",
+      "description": "Timestamp formatter omits year: multi-year records display identically.",
       "file": "frontend/src/lib/data-grid.ts",
-      "line": 25,
+      "line": 34,
       "type": "bug",
       "severity": "medium",
       "verified": true,
-      "conceded_by": ["advocate-1", "advocate-2"],
-      "fix_description": "Add year: 'numeric' to the Intl.DateTimeFormat options object at line 25-30.",
-      "citations": [
-        "frontend/src/lib/data-grid.ts:25-30"
-      ]
+      "conceded_by": ["advocate-1"],
+      "status": "FIXED",
+      "session": 1
     },
     {
       "id": 3,
@@ -49,10 +44,42 @@
       "type": "improvement",
       "severity": "medium",
       "verified": true,
-      "conceded_by": ["advocate-1", "advocate-2"],
-      "fix_description": "Add role=\"status\" to the sort indicator <div> element.",
+      "conceded_by": ["advocate-1"],
+      "status": "FIXED",
+      "session": 1
+    },
+    {
+      "id": 4,
+      "description": "Safari Invalid Date for timestamp without time zone: postgres.rs sends space-separated datetime, Safari rejects non-ISO format.",
+      "file": "frontend/src/lib/data-grid.ts",
+      "line": 137,
+      "type": "bug",
+      "severity": "high",
+      "verified": true,
+      "conceded_by": ["advocate-1"],
+      "status": "FIXED",
+      "session": 2,
+      "fix_description": "Replace space with T before new Date() for cross-browser ISO 8601 compliance.",
       "citations": [
-        "frontend/src/components/ToolStrip.svelte:57"
+        "frontend/src/lib/data-grid.ts:137",
+        "src/db/postgres.rs:401-403"
+      ]
+    },
+    {
+      "id": 5,
+      "description": "CSV export ignores active filters and sort state — user sees filtered view but exports full table.",
+      "file": "frontend/src/App.svelte",
+      "line": 207,
+      "type": "bug",
+      "severity": "medium",
+      "verified": true,
+      "conceded_by": ["advocate-1"],
+      "status": "FIXED",
+      "session": 2,
+      "fix_description": "Pass sortState and filters as query params to the export URL via buildRowsParams.",
+      "citations": [
+        "frontend/src/App.svelte:207-219",
+        "src/api/mod.rs:204-211"
       ]
     }
   ],
@@ -68,13 +95,34 @@
     {
       "claim": "ILIKE performance on 500K rows",
       "reason": "Pre-existing design choice from prior epic, not introduced by this PR."
+    },
+    {
+      "claim": "sortStateToConfig returns undefined breaks RevoGrid sort indicators",
+      "reason": "ADVOCATE rebutted: sort indicators are driven by per-column order prop (DataGrid.svelte:198-199), not the sorting prop. Clearing sortState sets all columns to order: undefined, which correctly removes arrows."
     }
   ],
   "follow_ups": [
-    "Add unit tests for data-grid.ts pure functions (formatCellValue, columnWidth, sortStateToConfig, buildSortableColumn, getColumnDisplayName)",
+    "Add unit tests for data-grid.ts pure functions",
     "Tighten sortStateToConfig return type to Record<string, 'asc' | 'desc'>",
-    "Expand boolean coercion for future SQLite support (value === 1, 'yes', 'on')",
+    "Expand boolean coercion for future SQLite support",
+    "Relax is_valid_identifier to allow hyphens in quoted identifiers (postgres.rs:169-171)",
     "Investigate aria-sort on RevoGrid column headers at runtime"
+  ],
+  "conditions_met": true,
+  "prior_sessions": [
+    {
+      "session": 1,
+      "findings": 3,
+      "fixed": 3,
+      "dismissed": 3
+    },
+    {
+      "session": 2,
+      "findings": 4,
+      "fixed": 2,
+      "tracked": 1,
+      "dismissed": 1
+    }
   ],
   "critical_discoveries": []
 }

--- a/.council/council-result.json
+++ b/.council/council-result.json
@@ -8,8 +8,8 @@
     "questioner": 0,
     "rounds": 2,
     "mode": "1v1-no-questioner",
-    "session": 6,
-    "note": "Session 6: 1v1 no-questioner. Finding 15 (ToolStrip export aria-label misinformation) fixed pre-merge. Findings 13 (dead decimal entry) and 14 (backslash in Content-Disposition) tracked as nits."
+    "session": 7,
+    "note": "Session 7: 1v1 no-questioner. One new low-severity finding (#16, search ILIKE identifier validation). All 6 previously tracked findings + finding #16 + dead currentPage arg fixed in this session. 16/16 findings now FIXED. PR clean."
   },
   "findings": [
     {
@@ -108,9 +108,11 @@
       "severity": "low",
       "verified": true,
       "conceded_by": ["advocate-1"],
-      "status": "TRACKED",
+      "status": "FIXED",
       "session": 3,
-      "note": "Both agents agreed post-merge is defensible — 2^53 threshold rarely hit in practice. Fix requires API-level decision (string-encode large bigints)."
+      "note": "Both agents agreed post-merge is defensible — 2^53 threshold rarely hit in practice. Fix requires API-level decision (string-encode large bigints).",
+      "fix_description": "Serialize bigint as string when unsigned_abs() > 2^53. Values within safe JS range remain JSON numbers.",
+      "fixed_session": 7
     },
     {
       "id": 8,
@@ -141,9 +143,11 @@
       "severity": "medium",
       "verified": true,
       "conceded_by": ["advocate-1"],
-      "status": "TRACKED",
+      "status": "FIXED",
       "session": 4,
-      "note": "Post-merge. RevoGrid's hyperscript layer may require DOM inspection to place aria-sort on the actual <th> element."
+      "note": "Post-merge. RevoGrid's hyperscript layer may require DOM inspection to place aria-sort on the actual <th> element.",
+      "fix_description": "Added aria-sort='ascending'/'descending' to header wrapper div in renderHeader via conditional spread.",
+      "fixed_session": 7
     },
     {
       "id": 10,
@@ -190,9 +194,11 @@
       "severity": "low",
       "verified": true,
       "conceded_by": ["advocate-1"],
-      "status": "TRACKED",
+      "status": "FIXED",
       "session": 5,
-      "note": "Both agents agreed toLocaleString() masks the artifact in the UI. Only raw API shows inconsistency — invisible to target non-technical users."
+      "note": "Both agents agreed toLocaleString() masks the artifact in the UI. Only raw API shows inconsistency — invisible to target non-technical users.",
+      "fix_description": "Parse f32 via to_string().parse::<f64>() to avoid widening artifacts in JSON serialization.",
+      "fixed_session": 7
     },
     {
       "id": 13,
@@ -203,9 +209,11 @@
       "severity": "nit",
       "verified": true,
       "conceded_by": ["advocate-1"],
-      "status": "TRACKED",
+      "status": "FIXED",
       "session": 6,
-      "note": "Both agents agreed: dead code, zero runtime impact, post-merge cleanup."
+      "note": "Both agents agreed: dead code, zero runtime impact, post-merge cleanup.",
+      "fix_description": "Removed 'decimal' from NUMERIC_TEXT_TYPES — PostgreSQL normalizes DECIMAL to 'numeric'.",
+      "fixed_session": 7
     },
     {
       "id": 14,
@@ -216,9 +224,11 @@
       "severity": "nit",
       "verified": true,
       "conceded_by": ["advocate-1"],
-      "status": "TRACKED",
+      "status": "FIXED",
       "session": 6,
-      "note": "CRITIC downgraded from Low to Nit. Display names are admin-configured, not user-exploitable. One-line fix: .replace('\\\\', \"\")."
+      "note": "CRITIC downgraded from Low to Nit. Display names are admin-configured, not user-exploitable. One-line fix: .replace('\\\\', \"\").",
+      "fix_description": "Added .replace('\\\\', \"\") to Content-Disposition filename sanitizer chain.",
+      "fixed_session": 7
     },
     {
       "id": 15,
@@ -236,6 +246,21 @@
         "frontend/src/components/ToolStrip.svelte:83-85",
         "frontend/src/App.svelte:271"
       ]
+    },
+    {
+      "id": 16,
+      "description": "Search ILIKE path interpolates schema-derived column names into SQL without is_valid_identifier guard — asymmetric with filter/sort paths which both validate. Column with embedded double-quote would produce broken SQL (500 error, not injection).",
+      "file": "src/db/postgres.rs",
+      "line": 211,
+      "type": "improvement",
+      "severity": "low",
+      "verified": true,
+      "conceded_by": ["advocate-1"],
+      "status": "FIXED",
+      "session": 7,
+      "note": "CRITIC initially recommended CONDITIONAL. ADVOCATE rebutted: c.name is schema metadata from information_schema, not user input; failure mode is 500 not injection; precondition (embedded double-quote in column name) is exotic. CRITIC conceded to TRACKED but correctly disputed ADVOCATE's Point 4 — pg_value_to_json uses try_get() as row key, not SQL interpolation. Trust boundary argument (points 1-3) was sufficient.",
+      "fix_description": "Added is_valid_identifier guard to search text_cols filter: .filter(|c| is_text_type(&c.data_type) && is_valid_identifier(&c.name))",
+      "fixed_session": 7
     }
   ],
   "dismissed": [
@@ -265,7 +290,8 @@
     "Add aria-sort attribute to RevoGrid column headers (WCAG 1.3.1)",
     "Normalize real (float4) JSON serialization to match CSV (use f32.to_string() instead of f32 as f64)",
     "Remove dead 'decimal' entry from NUMERIC_TEXT_TYPES (data-grid.ts:20)",
-    "Add backslash to Content-Disposition filename sanitizer (api/mod.rs:235)"
+    "Add backslash to Content-Disposition filename sanitizer (api/mod.rs:235)",
+    "Add is_valid_identifier guard to search ILIKE text_cols filter (postgres.rs:211)"
   ],
   "conditions_met": true,
   "prior_sessions": [
@@ -309,6 +335,14 @@
       "fixed": 1,
       "tracked": 2,
       "dismissed": 0
+    },
+    {
+      "session": 7,
+      "findings": 1,
+      "fixed": 7,
+      "tracked": 0,
+      "dismissed": 0,
+      "note": "1 new finding (#16) + 6 previously tracked findings all fixed"
     }
   ],
   "critical_discoveries": []

--- a/.council/council-result.json
+++ b/.council/council-result.json
@@ -8,8 +8,8 @@
     "questioner": 0,
     "rounds": 2,
     "mode": "1v1-no-questioner",
-    "session": 5,
-    "note": "Session 5: 1v1 no-questioner. Finding 10 (boolean filter mismatch) and 11 (numeric display regression) fixed pre-merge. Finding 12 (real grid/CSV inconsistency) tracked."
+    "session": 6,
+    "note": "Session 6: 1v1 no-questioner. Finding 15 (ToolStrip export aria-label misinformation) fixed pre-merge. Findings 13 (dead decimal entry) and 14 (backslash in Content-Disposition) tracked as nits."
   },
   "findings": [
     {
@@ -193,6 +193,49 @@
       "status": "TRACKED",
       "session": 5,
       "note": "Both agents agreed toLocaleString() masks the artifact in the UI. Only raw API shows inconsistency — invisible to target non-technical users."
+    },
+    {
+      "id": 13,
+      "description": "Dead 'decimal' entry in NUMERIC_TEXT_TYPES — PostgreSQL normalizes DECIMAL to 'numeric', so this Set entry can never match.",
+      "file": "frontend/src/lib/data-grid.ts",
+      "line": 20,
+      "type": "improvement",
+      "severity": "nit",
+      "verified": true,
+      "conceded_by": ["advocate-1"],
+      "status": "TRACKED",
+      "session": 6,
+      "note": "Both agents agreed: dead code, zero runtime impact, post-merge cleanup."
+    },
+    {
+      "id": 14,
+      "description": "Content-Disposition filename sanitizer missing backslash escape — RFC 2183 compliance gap for admin-configured display names containing backslash.",
+      "file": "src/api/mod.rs",
+      "line": 235,
+      "type": "improvement",
+      "severity": "nit",
+      "verified": true,
+      "conceded_by": ["advocate-1"],
+      "status": "TRACKED",
+      "session": 6,
+      "note": "CRITIC downgraded from Low to Nit. Display names are admin-configured, not user-exploitable. One-line fix: .replace('\\\\', \"\")."
+    },
+    {
+      "id": 15,
+      "description": "ToolStrip export button aria-label says 'Export tools coming later' but CSV export already works via Toolbar — misinforms screen reader users.",
+      "file": "frontend/src/components/ToolStrip.svelte",
+      "line": 83,
+      "type": "accessibility",
+      "severity": "medium",
+      "verified": true,
+      "conceded_by": ["advocate-1"],
+      "status": "FIXED",
+      "session": 6,
+      "fix_description": "Changed aria-label and title to 'More export options coming soon' to disambiguate from the existing Toolbar CSV export.",
+      "citations": [
+        "frontend/src/components/ToolStrip.svelte:83-85",
+        "frontend/src/App.svelte:271"
+      ]
     }
   ],
   "dismissed": [
@@ -220,7 +263,9 @@
     "Serialize bigint as string in postgres.rs for values > Number.MAX_SAFE_INTEGER",
     "Remove dead currentPage arg from exportCsv buildRowsParams call (App.svelte:209)",
     "Add aria-sort attribute to RevoGrid column headers (WCAG 1.3.1)",
-    "Normalize real (float4) JSON serialization to match CSV (use f32.to_string() instead of f32 as f64)"
+    "Normalize real (float4) JSON serialization to match CSV (use f32.to_string() instead of f32 as f64)",
+    "Remove dead 'decimal' entry from NUMERIC_TEXT_TYPES (data-grid.ts:20)",
+    "Add backslash to Content-Disposition filename sanitizer (api/mod.rs:235)"
   ],
   "conditions_met": true,
   "prior_sessions": [
@@ -256,6 +301,13 @@
       "findings": 3,
       "fixed": 2,
       "tracked": 1,
+      "dismissed": 0
+    },
+    {
+      "session": 6,
+      "findings": 3,
+      "fixed": 1,
+      "tracked": 2,
       "dismissed": 0
     }
   ],

--- a/.council/council-result.json
+++ b/.council/council-result.json
@@ -8,8 +8,8 @@
     "questioner": 0,
     "rounds": 2,
     "mode": "1v1-no-questioner",
-    "session": 2,
-    "note": "Session 2: post-fix review. All pre-merge findings from sessions 1+2 resolved. No new pre-merge blockers."
+    "session": 3,
+    "note": "Session 3: 1v1 no-questioner. Finding 6 (numeric precision) fixed pre-merge. Finding 7 (bigint) tracked as follow-up."
   },
   "findings": [
     {
@@ -83,6 +83,37 @@
       ]
     }
   ],
+    {
+      "id": 6,
+      "description": "numeric/decimal columns lose precision: NUMBER_TYPES includes 'numeric' and 'decimal', causing Number() cast on backend string values — float64 rounds beyond 15 significant digits.",
+      "file": "frontend/src/lib/data-grid.ts",
+      "line": 14,
+      "type": "bug",
+      "severity": "high",
+      "verified": true,
+      "conceded_by": ["advocate-1"],
+      "status": "FIXED",
+      "session": 3,
+      "fix_description": "Removed 'numeric' and 'decimal' from NUMBER_TYPES so they fall through to the text formatter, preserving the backend's full-precision string.",
+      "citations": [
+        "frontend/src/lib/data-grid.ts:14-15",
+        "src/db/postgres.rs:390-393"
+      ]
+    },
+    {
+      "id": 7,
+      "description": "bigint values > 2^53 lose precision in JSON transport: postgres.rs serializes i64 as JSON number, JavaScript JSON.parse converts to float64.",
+      "file": "src/db/postgres.rs",
+      "line": 382,
+      "type": "bug",
+      "severity": "low",
+      "verified": true,
+      "conceded_by": ["advocate-1"],
+      "status": "TRACKED",
+      "session": 3,
+      "note": "Both agents agreed post-merge is defensible — 2^53 threshold rarely hit in practice. Fix requires API-level decision (string-encode large bigints)."
+    }
+  ],
   "dismissed": [
     {
       "claim": "on:beforesorting is wrong Svelte 5 syntax",
@@ -105,7 +136,8 @@
     "Add unit tests for data-grid.ts pure functions",
     "Tighten sortStateToConfig return type to Record<string, 'asc' | 'desc'>",
     "Expand boolean coercion for future SQLite support",
-    "Relax is_valid_identifier to allow hyphens in quoted identifiers (postgres.rs:169-171)",
+    "Serialize bigint as string in postgres.rs for values > Number.MAX_SAFE_INTEGER",
+    "Remove dead currentPage arg from exportCsv buildRowsParams call (App.svelte:209)",
     "Investigate aria-sort on RevoGrid column headers at runtime"
   ],
   "conditions_met": true,
@@ -122,6 +154,13 @@
       "fixed": 2,
       "tracked": 1,
       "dismissed": 1
+    },
+    {
+      "session": 3,
+      "findings": 2,
+      "fixed": 1,
+      "tracked": 1,
+      "dismissed": 0
     }
   ],
   "critical_discoveries": []

--- a/.council/council-result.json
+++ b/.council/council-result.json
@@ -8,8 +8,8 @@
     "questioner": 0,
     "rounds": 2,
     "mode": "1v1-no-questioner",
-    "session": 4,
-    "note": "Session 4: 1v1 no-questioner. Finding 8 (real/float4 silent null) fixed pre-merge. Finding 9 (aria-sort) tracked as follow-up."
+    "session": 5,
+    "note": "Session 5: 1v1 no-questioner. Finding 10 (boolean filter mismatch) and 11 (numeric display regression) fixed pre-merge. Finding 12 (real grid/CSV inconsistency) tracked."
   },
   "findings": [
     {
@@ -144,6 +144,55 @@
       "status": "TRACKED",
       "session": 4,
       "note": "Post-merge. RevoGrid's hyperscript layer may require DOM inspection to place aria-sort on the actual <th> element."
+    },
+    {
+      "id": 10,
+      "description": "Boolean filter broken: users see Yes/No badges but must type 'true'/'false' to filter — ::text ILIKE casts boolean to 'true'/'false', not 'yes'/'no'.",
+      "file": "src/db/postgres.rs",
+      "line": 226,
+      "related_files": ["frontend/src/lib/data-grid.ts:106-111"],
+      "type": "bug",
+      "severity": "high",
+      "verified": true,
+      "conceded_by": ["advocate-1"],
+      "status": "FIXED",
+      "session": 5,
+      "fix_description": "Boolean columns now use = TRUE/FALSE comparison instead of ::text ILIKE. Filter input mapped: yes/true/t/1 → TRUE, no/false/f/0 → FALSE. Non-matching input yields no rows.",
+      "citations": [
+        "src/db/postgres.rs:221-248",
+        "frontend/src/lib/data-grid.ts:106-111"
+      ]
+    },
+    {
+      "id": 11,
+      "description": "numeric/decimal columns display as left-aligned plain text — no tabular-nums, no right-alignment. Session 3 precision fix removed from NUMBER_TYPES but display classification was never updated.",
+      "file": "frontend/src/lib/data-grid.ts",
+      "line": 10,
+      "type": "bug",
+      "severity": "medium",
+      "verified": true,
+      "conceded_by": ["advocate-1"],
+      "status": "FIXED",
+      "session": 5,
+      "fix_description": "Added NUMERIC_TEXT_TYPES set for 'numeric'/'decimal'. Returns kind: 'number' with raw string display (no Number() cast), giving right-alignment and tabular-nums without precision loss.",
+      "citations": [
+        "frontend/src/lib/data-grid.ts:16-21",
+        "frontend/src/lib/data-grid.ts:152-157"
+      ]
+    },
+    {
+      "id": 12,
+      "description": "real (float4) grid vs CSV serialization inconsistency: f32 as f64 widening in JSON produces artifacts (3.140000104904175) while f32.to_string() in CSV is clean (3.14).",
+      "file": "src/db/postgres.rs",
+      "line": 388,
+      "related_files": ["src/api/mod.rs:380"],
+      "type": "bug",
+      "severity": "low",
+      "verified": true,
+      "conceded_by": ["advocate-1"],
+      "status": "TRACKED",
+      "session": 5,
+      "note": "Both agents agreed toLocaleString() masks the artifact in the UI. Only raw API shows inconsistency — invisible to target non-technical users."
     }
   ],
   "dismissed": [
@@ -170,7 +219,8 @@
     "Expand boolean coercion for future SQLite support",
     "Serialize bigint as string in postgres.rs for values > Number.MAX_SAFE_INTEGER",
     "Remove dead currentPage arg from exportCsv buildRowsParams call (App.svelte:209)",
-    "Add aria-sort attribute to RevoGrid column headers (WCAG 1.3.1)"
+    "Add aria-sort attribute to RevoGrid column headers (WCAG 1.3.1)",
+    "Normalize real (float4) JSON serialization to match CSV (use f32.to_string() instead of f32 as f64)"
   ],
   "conditions_met": true,
   "prior_sessions": [
@@ -198,6 +248,13 @@
       "session": 4,
       "findings": 2,
       "fixed": 1,
+      "tracked": 1,
+      "dismissed": 0
+    },
+    {
+      "session": 5,
+      "findings": 3,
+      "fixed": 2,
       "tracked": 1,
       "dismissed": 0
     }

--- a/.council/council-result.json
+++ b/.council/council-result.json
@@ -8,8 +8,8 @@
     "questioner": 0,
     "rounds": 2,
     "mode": "1v1-no-questioner",
-    "session": 7,
-    "note": "Session 7: 1v1 no-questioner. One new low-severity finding (#16, search ILIKE identifier validation). All 6 previously tracked findings + finding #16 + dead currentPage arg fixed in this session. 16/16 findings now FIXED. PR clean."
+    "session": 8,
+    "note": "Session 8: 1v1 no-questioner. Fresh review of current code state. 1 finding dismissed (pre-existing get_columns_bulk schema filter from PR #27). 3 new post-merge follow-ups tracked: formatCellValue test gap, Content-Disposition non-ASCII filenames, missing type=button. 1 noted: ToolStrip role=status live region noisiness. No pre-merge blockers."
   },
   "findings": [
     {
@@ -279,19 +279,19 @@
     {
       "claim": "sortStateToConfig returns undefined breaks RevoGrid sort indicators",
       "reason": "ADVOCATE rebutted: sort indicators are driven by per-column order prop (DataGrid.svelte:198-199), not the sorting prop. Clearing sortState sets all columns to order: undefined, which correctly removes arrows."
+    },
+    {
+      "claim": "get_columns_bulk PK subquery missing table_schema filter",
+      "reason": "Session 8: ARBITER verified both get_columns and get_columns_bulk exist on main since PR #27 (Epic 1) with identical missing table_schema pattern. Pre-existing code, not introduced by this PR. CRITIC withdrew."
     }
   ],
   "follow_ups": [
-    "Add unit tests for data-grid.ts pure functions",
+    "Add unit tests for data-grid.ts pure functions (formatCellValue, columnWidth, sortStateToConfig) — session 8 F2",
+    "Add RFC 6266 filename*=UTF-8'' encoding for non-ASCII Content-Disposition filenames — session 8 F3",
+    "Add type='button' to TableList.svelte:43, StatusBar.svelte:33,41 — session 8 F4",
+    "Consider replacing role='status' on ToolStrip sort indicator with non-live aria-label — session 8 noted",
     "Tighten sortStateToConfig return type to Record<string, 'asc' | 'desc'>",
-    "Expand boolean coercion for future SQLite support",
-    "Serialize bigint as string in postgres.rs for values > Number.MAX_SAFE_INTEGER",
-    "Remove dead currentPage arg from exportCsv buildRowsParams call (App.svelte:209)",
-    "Add aria-sort attribute to RevoGrid column headers (WCAG 1.3.1)",
-    "Normalize real (float4) JSON serialization to match CSV (use f32.to_string() instead of f32 as f64)",
-    "Remove dead 'decimal' entry from NUMERIC_TEXT_TYPES (data-grid.ts:20)",
-    "Add backslash to Content-Disposition filename sanitizer (api/mod.rs:235)",
-    "Add is_valid_identifier guard to search ILIKE text_cols filter (postgres.rs:211)"
+    "Expand boolean coercion for future SQLite support"
   ],
   "conditions_met": true,
   "prior_sessions": [
@@ -343,6 +343,15 @@
       "tracked": 0,
       "dismissed": 0,
       "note": "1 new finding (#16) + 6 previously tracked findings all fixed"
+    },
+    {
+      "session": 8,
+      "findings": 4,
+      "fixed": 0,
+      "tracked": 3,
+      "noted": 1,
+      "dismissed": 1,
+      "note": "Fresh review. 1 dismissed (pre-existing). 3 tracked post-merge (test gap, non-ASCII filename, type=button). 1 noted (role=status noisiness). No pre-merge blockers."
     }
   ],
   "critical_discoveries": []

--- a/.council/council-result.json
+++ b/.council/council-result.json
@@ -1,95 +1,80 @@
 {
-  "motion": "Should PR #28: epic: Frontend Scaffold & Integration be merged into main?",
-  "verdict": "FOR",
+  "motion": "Merge PR #29: epic: Data Grid & Table Navigation",
+  "verdict": "CONDITIONAL",
   "date": "2026-04-09",
-  "council": {
-    "advocates": 1,
-    "critics": 1,
-    "questioner": 0,
-    "rounds": 2,
-    "mode": "1v1-no-questioner",
-    "session": 3,
-    "note": "Final review after sessions 1+2 fixed all pre-merge findings. No new pre-merge blockers found."
+  "rounds": 3,
+  "agents": {
+    "advocate-1": "CONDITIONAL",
+    "advocate-2": "CONDITIONAL",
+    "critic-1": "CONDITIONAL",
+    "critic-2": "CONDITIONAL",
+    "questioner": "2 bugs confirmed, 0 unsubstantiated"
   },
   "findings": [
     {
       "id": 1,
-      "description": "setup.rs CWD write — CRITIC claimed new in this PR; arbiter verified pre-existing in main since Epic 1 (commit c276345, PR #27). CWD write is symmetric with config.rs:202-207 loader.",
-      "file": "src/api/setup.rs",
-      "line": 155,
-      "type": "improvement",
-      "severity": "medium",
+      "description": "Date off-by-one for non-UTC users: new Date() on bare date string parses as UTC midnight, rendered in local timezone shows wrong day. Also shows spurious time components for date-only fields.",
+      "file": "frontend/src/lib/data-grid.ts",
+      "line": 111,
+      "type": "bug",
+      "severity": "high",
       "verified": true,
-      "conceded_by": [],
-      "classification": "dismissed",
-      "status": "DISMISSED",
-      "dismissal_reason": "Pre-existing code merged via Epic 1 (PR #27, commit c276345). Not introduced by this PR. CWD write is symmetric with find_config_file() at config.rs:202-207."
+      "conceded_by": ["advocate-1", "advocate-2"],
+      "fix_description": "Detect date-only columns (column.data_type === 'date') and either append 'T00:00:00' for local parsing or use a separate date-only formatter without time components.",
+      "citations": [
+        "frontend/src/lib/data-grid.ts:111",
+        "frontend/src/lib/data-grid.ts:18-23",
+        "src/db/postgres.rs:408-411"
+      ]
     },
     {
       "id": 2,
-      "description": "Toolbar shows previous table's display name during table-switch loading — selectedTable updates after fetch completes at App.svelte:62",
-      "file": "frontend/src/App.svelte",
-      "line": 62,
-      "related_files": ["frontend/src/App.svelte:143", "frontend/src/App.svelte:153-158"],
-      "type": "improvement",
-      "severity": "low",
+      "description": "Timestamp formatter omits year: multi-year records display identically (e.g. 'Jan 15, 3:45 PM' for both 2023 and 2024). Year only visible in tooltip.",
+      "file": "frontend/src/lib/data-grid.ts",
+      "line": 25,
+      "type": "bug",
+      "severity": "medium",
       "verified": true,
-      "conceded_by": ["advocate-1"],
-      "classification": "post-merge",
-      "status": "TRACKED",
-      "note": "ADVOCATE concedes the label lags but argues deliberate UX trade-off: updating early would show new name over stale rows. Loading overlay and spinner signal transition. Arbiter agrees — design choice, not bug."
+      "conceded_by": ["advocate-1", "advocate-2"],
+      "fix_description": "Add year: 'numeric' to the Intl.DateTimeFormat options object at line 25-30.",
+      "citations": [
+        "frontend/src/lib/data-grid.ts:25-30"
+      ]
     },
     {
       "id": 3,
-      "description": "Justfile dev recipe: background cargo process survives Ctrl+C because kill line never runs when SIGINT hits the subshell",
-      "file": "Justfile",
-      "line": 9,
+      "description": "ToolStrip sort indicator div has aria-label but no role — invisible to assistive technology.",
+      "file": "frontend/src/components/ToolStrip.svelte",
+      "line": 57,
       "type": "improvement",
-      "severity": "low",
+      "severity": "medium",
       "verified": true,
-      "conceded_by": ["advocate-1"],
-      "classification": "post-merge",
-      "status": "TRACKED"
-    },
-    {
-      "id": 4,
-      "description": "pick<T>() in mock.ts returns undefined on empty arrays despite T return type — type unsoundness in dev-only mock layer",
-      "file": "frontend/src/lib/mock.ts",
-      "line": 326,
-      "type": "improvement",
-      "severity": "nit",
-      "verified": true,
-      "conceded_by": ["advocate-1"],
-      "classification": "post-merge",
-      "status": "TRACKED"
+      "conceded_by": ["advocate-1", "advocate-2"],
+      "fix_description": "Add role=\"status\" to the sort indicator <div> element.",
+      "citations": [
+        "frontend/src/components/ToolStrip.svelte:57"
+      ]
     }
   ],
   "dismissed": [
     {
-      "id": 1,
-      "reason": "Pre-existing code from Epic 1 (main branch), not introduced by this PR"
-    }
-  ],
-  "conditions_met": true,
-  "prior_sessions": [
-    {
-      "session": 1,
-      "findings": 8,
-      "fixed": 8,
-      "dismissed": 1
+      "claim": "on:beforesorting is wrong Svelte 5 syntax",
+      "reason": "QUESTIONER verified @revolist/svelte-datagrid v4.21.4 uses createEventDispatcher (Svelte 4), so on: syntax is correct from Svelte 5 consumers."
     },
     {
-      "session": 2,
-      "findings": 9,
-      "fixed": 2,
-      "tracked": 7,
-      "dismissed": 0
+      "claim": "Boolean coercion misses 1/yes/on",
+      "reason": "QUESTIONER verified postgres.rs:394-396 sends JSON booleans. Non-boolean representations cannot arrive from current backend."
+    },
+    {
+      "claim": "ILIKE performance on 500K rows",
+      "reason": "Pre-existing design choice from prior epic, not introduced by this PR."
     }
   ],
-  "follow_up_issues": [
-    "Consider updating selectedTable before fetch for immediate toolbar feedback",
-    "Add trap to Justfile dev recipe to kill background cargo on SIGINT",
-    "Fix pick<T>() type safety in mock.ts"
+  "follow_ups": [
+    "Add unit tests for data-grid.ts pure functions (formatCellValue, columnWidth, sortStateToConfig, buildSortableColumn, getColumnDisplayName)",
+    "Tighten sortStateToConfig return type to Record<string, 'asc' | 'desc'>",
+    "Expand boolean coercion for future SQLite support (value === 1, 'yes', 'on')",
+    "Investigate aria-sort on RevoGrid column headers at runtime"
   ],
   "critical_discoveries": []
 }

--- a/.council/council-result.json
+++ b/.council/council-result.json
@@ -8,8 +8,8 @@
     "questioner": 0,
     "rounds": 2,
     "mode": "1v1-no-questioner",
-    "session": 3,
-    "note": "Session 3: 1v1 no-questioner. Finding 6 (numeric precision) fixed pre-merge. Finding 7 (bigint) tracked as follow-up."
+    "session": 4,
+    "note": "Session 4: 1v1 no-questioner. Finding 8 (real/float4 silent null) fixed pre-merge. Finding 9 (aria-sort) tracked as follow-up."
   },
   "findings": [
     {
@@ -81,8 +81,7 @@
         "frontend/src/App.svelte:207-219",
         "src/api/mod.rs:204-211"
       ]
-    }
-  ],
+    },
     {
       "id": 6,
       "description": "numeric/decimal columns lose precision: NUMBER_TYPES includes 'numeric' and 'decimal', causing Number() cast on backend string values — float64 rounds beyond 15 significant digits.",
@@ -112,6 +111,39 @@
       "status": "TRACKED",
       "session": 3,
       "note": "Both agents agreed post-merge is defensible — 2^53 threshold rarely hit in practice. Fix requires API-level decision (string-encode large bigints)."
+    },
+    {
+      "id": 8,
+      "description": "real (float4) columns silently null out: try_get::<f64> fails OID check against FLOAT4 (OID 700 vs 701), every real value rendered as NULL.",
+      "file": "src/db/postgres.rs",
+      "line": 386,
+      "related_files": ["src/api/mod.rs:378-381"],
+      "type": "bug",
+      "severity": "high",
+      "verified": true,
+      "conceded_by": ["advocate-1"],
+      "status": "FIXED",
+      "session": 4,
+      "fix_description": "Split 'real' | 'double precision' arm: use try_get::<f32> for real, try_get::<f64> for double precision. Applied in both pg_value_to_json and pg_value_to_csv_string.",
+      "citations": [
+        "src/db/postgres.rs:386-389",
+        "src/api/mod.rs:378-381",
+        "sqlx-postgres-0.8.6/src/types/float.rs:9-13,38-42",
+        "sqlx-postgres-0.8.6/src/type_info.rs:1053-1058"
+      ]
+    },
+    {
+      "id": 9,
+      "description": "Missing aria-sort on sorted column headers: renderHeader sets aria-hidden on sort arrow but no aria-sort attribute on header div. WCAG 1.3.1 Level A violation.",
+      "file": "frontend/src/components/DataGrid.svelte",
+      "line": 66,
+      "type": "accessibility",
+      "severity": "medium",
+      "verified": true,
+      "conceded_by": ["advocate-1"],
+      "status": "TRACKED",
+      "session": 4,
+      "note": "Post-merge. RevoGrid's hyperscript layer may require DOM inspection to place aria-sort on the actual <th> element."
     }
   ],
   "dismissed": [
@@ -138,7 +170,7 @@
     "Expand boolean coercion for future SQLite support",
     "Serialize bigint as string in postgres.rs for values > Number.MAX_SAFE_INTEGER",
     "Remove dead currentPage arg from exportCsv buildRowsParams call (App.svelte:209)",
-    "Investigate aria-sort on RevoGrid column headers at runtime"
+    "Add aria-sort attribute to RevoGrid column headers (WCAG 1.3.1)"
   ],
   "conditions_met": true,
   "prior_sessions": [
@@ -157,6 +189,13 @@
     },
     {
       "session": 3,
+      "findings": 2,
+      "fixed": 1,
+      "tracked": 1,
+      "dismissed": 0
+    },
+    {
+      "session": 4,
       "findings": 2,
       "fixed": 1,
       "tracked": 1,

--- a/.council/fix-manifest.md
+++ b/.council/fix-manifest.md
@@ -1,18 +1,44 @@
-# Fix Manifest — PR #29: epic: Data Grid & Table Navigation (Session 6)
+# Fix Manifest — PR #29: epic: Data Grid & Table Navigation (Session 7)
 
-Council verdict: **FOR** | 2026-04-09 | 15 findings (15 verified) | 1v1 no-questioner | 2 rounds
+Council verdict: **FOR** | 2026-04-10 | 16 findings (16 verified, 16 FIXED) | 1v1 no-questioner | 2 rounds
 
-Prior sessions: Session 1 (3 fixed, 3 dismissed), Session 2 (2 fixed, 1 tracked, 1 dismissed), Session 3 (1 fixed, 1 tracked), Session 4 (1 fixed, 1 tracked), Session 5 (2 fixed, 1 tracked).
+Prior sessions: Session 1 (3 fixed, 3 dismissed), Session 2 (2 fixed, 1 tracked, 1 dismissed), Session 3 (1 fixed, 1 tracked), Session 4 (1 fixed, 1 tracked), Session 5 (2 fixed, 1 tracked), Session 6 (1 fixed, 2 tracked), Session 7 (1 new finding + 6 previously tracked — all 7 fixed).
 
-## Session 6 Fixes (applied in this commit)
+## All Findings Resolved
 
-### 1. ToolStrip export aria-label misinforms users
-- **File**: `frontend/src/components/ToolStrip.svelte:83-85`
-- **Severity**: medium
-- **Fix**: Changed `aria-label="Export tools coming later"` to `"More export options coming soon"` — disambiguates from the existing working CSV export in the Toolbar.
-- **Conceded by**: ADVOCATE (full concession — factually incorrect accessible text)
+All 16 findings across 7 sessions have been fixed. No tracked or open items remain.
 
-## Prior Session Fixes
+## Session 7 Fixes
+
+### 1. bigint > 2^53 precision loss in JSON transport
+- **File**: `src/db/postgres.rs:405-408`
+- **Fix**: Serialize bigint as string when `unsigned_abs() > 2^53`; values within safe JS range remain JSON numbers.
+
+### 2. Dead currentPage arg in exportCsv
+- **File**: `frontend/src/App.svelte:209`
+- **Fix**: Changed `buildRowsParams(currentPage)` to `buildRowsParams(1)` — page is unused for CSV export.
+
+### 3. Missing aria-sort on sorted column headers (WCAG 1.3.1)
+- **File**: `frontend/src/components/DataGrid.svelte:66`
+- **Fix**: Added `aria-sort="ascending"`/`"descending"` to header wrapper div via conditional spread.
+
+### 4. real (float4) grid vs CSV serialization inconsistency
+- **File**: `src/db/postgres.rs:409-412`
+- **Fix**: Parse f32 via `to_string().parse::<f64>()` to avoid widening artifacts (e.g., 3.14 not 3.140000104904175).
+
+### 5. Dead 'decimal' entry in NUMERIC_TEXT_TYPES
+- **File**: `frontend/src/lib/data-grid.ts:20`
+- **Fix**: Removed — PostgreSQL normalizes DECIMAL to 'numeric'.
+
+### 6. Content-Disposition missing backslash escape
+- **File**: `src/api/mod.rs:233`
+- **Fix**: Added `.replace('\\', "")` to filename sanitizer chain.
+
+### 7. Search ILIKE path skips identifier validation on schema-derived column names
+- **File**: `src/db/postgres.rs:211`
+- **Fix**: Added `&& is_valid_identifier(&c.name)` to the `text_cols` filter chain.
+
+## Prior Session Fixes (sessions 1-6)
 
 ### Session 1
 1. **Date off-by-one for non-UTC users** — `data-grid.ts`: separate DATE_ONLY_TYPES, append T00:00:00
@@ -33,39 +59,10 @@ Prior sessions: Session 1 (3 fixed, 3 dismissed), Session 2 (2 fixed, 1 tracked,
 1. **Boolean filter broken: Yes/No display vs true/false SQL cast** — `postgres.rs:221-248`: use = TRUE/FALSE instead of ::text ILIKE
 2. **numeric/decimal columns display as left-aligned plain text** — `data-grid.ts:16-21, 152-157`: added NUMERIC_TEXT_TYPES set
 
-## Tracked (post-merge, not blocking)
+### Session 6
+1. **ToolStrip export aria-label misinforms users** — `ToolStrip.svelte:83-85`: changed to "More export options coming soon"
 
-### 1. bigint values > 2^53 lose precision in JSON transport
-- **File**: `src/db/postgres.rs:382-386`
-- **Severity**: low (2^53 threshold rarely hit in practice)
-- **Fix**: Serialize bigint as string for values > Number.MAX_SAFE_INTEGER
-
-### 2. Dead currentPage arg in exportCsv
-- **File**: `frontend/src/App.svelte:209`
-- **Severity**: nit
-- **Fix**: Remove unused page param from `buildRowsParams` call in `exportCsv`
-
-### 3. Missing aria-sort on sorted column headers (WCAG 1.3.1)
-- **File**: `frontend/src/components/DataGrid.svelte:66-100`
-- **Severity**: medium
-- **Fix**: Add `aria-sort="ascending"` / `"descending"` to header div in renderHeader
-
-### 4. real (float4) grid vs CSV serialization inconsistency
-- **File**: `src/db/postgres.rs:388`, `src/api/mod.rs:380`
-- **Severity**: low
-- **Fix**: Use `f32.to_string()` then parse for JSON instead of `f32 as f64` widening
-
-### 5. Dead 'decimal' entry in NUMERIC_TEXT_TYPES
-- **File**: `frontend/src/lib/data-grid.ts:20`
-- **Severity**: nit
-- **Fix**: Remove the entry — PostgreSQL normalizes DECIMAL to 'numeric'
-
-### 6. Content-Disposition missing backslash escape
-- **File**: `src/api/mod.rs:235`
-- **Severity**: nit
-- **Fix**: Add `.replace('\\', "")` to filename sanitizer chain
-
-## Dismissed (sessions 1-4)
+## Dismissed (sessions 1-6)
 - `on:beforesorting` Svelte 5 syntax — correct for Svelte 4 dispatcher consumed by Svelte 5
 - Boolean coercion misses 1/yes/on — backend sends JSON booleans only
 - ILIKE performance on 500K rows — pre-existing design choice

--- a/.council/fix-manifest.md
+++ b/.council/fix-manifest.md
@@ -1,43 +1,45 @@
-# Fix Manifest — PR #29: epic: Data Grid & Table Navigation (Session 2)
+# Fix Manifest — PR #29: epic: Data Grid & Table Navigation (Session 3)
 
-Council verdict: **FOR** | 2026-04-09 | 4 findings (4 verified, 1 dismissed) | 1v1 no-questioner | 2 rounds
+Council verdict: **CONDITIONAL→FOR** | 2026-04-09 | 7 findings (7 verified) | 1v1 no-questioner | 2 rounds
 
-Prior session: Session 1 (3 findings, all fixed, 3 dismissed).
+Prior sessions: Session 1 (3 findings, all fixed, 3 dismissed), Session 2 (2 fixed, 1 tracked, 1 dismissed).
 
-## No Fixes Required (pre-merge)
+## Session 3 Fix (applied in this commit)
 
-All pre-merge issues from sessions 1+2 have been resolved.
+### 1. numeric/decimal precision loss via Number() cast
+- **File**: `frontend/src/lib/data-grid.ts:14-15`
+- **Severity**: high
+- **Fix**: Removed `'numeric'` and `'decimal'` from `NUMBER_TYPES`. Backend already sends full-precision string (`postgres.rs:391`); values now fall through to the text formatter at `data-grid.ts:158-161`.
+- **Conceded by**: ADVOCATE (partially — agreed bug is real, contested blocking status)
 
-### Session 1 Fixes (applied in prior commit)
+## Prior Session Fixes
 
-1. **Date off-by-one for non-UTC users** — `data-grid.ts`: separate DATE_ONLY_TYPES, append T00:00:00, use dateFormatter
+### Session 1
+1. **Date off-by-one for non-UTC users** — `data-grid.ts`: separate DATE_ONLY_TYPES, append T00:00:00
 2. **Timestamp formatter omits year** — `data-grid.ts`: added year: 'numeric' to Intl.DateTimeFormat
 3. **ToolStrip sort indicator missing ARIA role** — `ToolStrip.svelte`: added role="status"
 
-### Session 2 Fixes (applied in this commit)
-
-#### 1. Safari Invalid Date for `timestamp without time zone`
-- **File**: `frontend/src/lib/data-grid.ts:137`
-- **Severity**: high
-- **Fix**: Replace space with T before `new Date()` — `new Date(raw.replace(' ', 'T'))`
-- **Conceded by**: ADVOCATE
-
-#### 2. CSV export ignores active filters/sort
-- **File**: `frontend/src/App.svelte:207-219`
-- **Severity**: medium
-- **Fix**: Pass `buildRowsParams()` as query params to the export URL
-- **Conceded by**: ADVOCATE
-
-### Dismissed: sortStateToConfig returns undefined
-- **Claim**: RevoGrid sort indicators not cleared when `sorting` is `undefined`
-- **Reason**: ADVOCATE rebutted — sort indicators driven by per-column `order` prop (`DataGrid.svelte:198-199`), not `sorting` object prop
+### Session 2
+1. **Safari Invalid Date for `timestamp without time zone`** — `data-grid.ts:137`: replace space with T
+2. **CSV export ignores active filters/sort** — `App.svelte:207-219`: pass sort/filter params to export URL
 
 ## Tracked (post-merge, not blocking)
 
-### 1. is_valid_identifier rejects hyphenated identifiers
-- **File**: `src/db/postgres.rs:169-171`
-- **Severity**: medium
-- **Fix**: Add hyphen to the identifier allowlist (safe inside double-quotes)
+### 1. bigint values > 2^53 lose precision in JSON transport
+- **File**: `src/db/postgres.rs:382-386`
+- **Severity**: low (2^53 threshold rarely hit in practice)
+- **Fix**: Serialize bigint as string for values > Number.MAX_SAFE_INTEGER
+
+### 2. Dead currentPage arg in exportCsv
+- **File**: `frontend/src/App.svelte:209`
+- **Severity**: nit
+- **Fix**: Remove unused page param from `buildRowsParams` call in `exportCsv`
+
+## Dismissed (sessions 1-2)
+- `on:beforesorting` Svelte 5 syntax — correct for Svelte 4 dispatcher consumed by Svelte 5
+- Boolean coercion misses 1/yes/on — backend sends JSON booleans only
+- ILIKE performance on 500K rows — pre-existing design choice
+- sortStateToConfig returns undefined — sort indicators driven by per-column `order` prop
 
 ## Test Command
 ```bash

--- a/.council/fix-manifest.md
+++ b/.council/fix-manifest.md
@@ -1,37 +1,51 @@
-# Fix Manifest -- PR #28: epic: Frontend Scaffold & Integration (Session 3)
+# Fix Manifest — PR #29: epic: Data Grid & Table Navigation
 
-Council verdict: **FOR** | 2026-04-09 | 4 findings (4 verified, 1 dismissed) | 1v1 no-questioner | 2 rounds
+Council verdict: **CONDITIONAL** | 2026-04-09 | 3 findings (3 verified)
 
-Prior sessions: Session 1 (8 findings, all fixed), Session 2 (9 findings, 2 pre-merge fixed, 7 tracked).
+## Fixes Required
 
-## No Fixes Required (pre-merge)
+### 1. Date off-by-one for non-UTC users
+- **File**: `frontend/src/lib/data-grid.ts`
+- **Line**: 111
+- **Type**: bug
+- **Severity**: high
+- **Verification**: verified
+- **Fix**: Detect date-only columns (`column.data_type === 'date'`) and either:
+  (a) Append `'T00:00:00'` to force local-timezone parsing, or
+  (b) Use a separate date-only `Intl.DateTimeFormat` (no hour/minute) for `date` columns.
+  Date columns should NOT show time components in the display.
+- **Citations**: `data-grid.ts:111`, `data-grid.ts:18-23`, `postgres.rs:408-411`
 
-All pre-merge issues from prior sessions have been resolved. Session 3 found no new pre-merge blockers.
+### 2. Timestamp formatter omits year
+- **File**: `frontend/src/lib/data-grid.ts`
+- **Line**: 25
+- **Type**: bug
+- **Severity**: medium
+- **Verification**: verified
+- **Fix**: Add `year: 'numeric'` to the `Intl.DateTimeFormat` options at lines 25-30.
+- **Citations**: `data-grid.ts:25-30`
 
-### Dismissed: setup.rs CWD write
-- **File**: `src/api/setup.rs:155`
-- **Reason**: CRITIC claimed new code in this PR. Arbiter verified via `git log main -- src/api/setup.rs` that `save_config` was merged in Epic 1 (commit c276345, PR #27). CWD write is symmetric with `config.rs:202-207` loader. Not in scope.
+### 3. ToolStrip sort indicator missing ARIA role
+- **File**: `frontend/src/components/ToolStrip.svelte`
+- **Line**: 57
+- **Type**: improvement
+- **Severity**: medium
+- **Verification**: verified
+- **Fix**: Add `role="status"` to the sort indicator `<div>` element.
+- **Citations**: `ToolStrip.svelte:57`
 
-## Tracked (post-merge, not blocking)
+## Conditions
+- All 3 fixes must be applied before merge
 
-### 1. Toolbar shows previous table name during loading
-- **File**: `frontend/src/App.svelte:62`
-- **Severity**: low
-- **Fix**: Move `selectedTable = tableName` before the `await`, or accept as deliberate UX trade-off
-
-### 2. Justfile dev recipe orphans cargo on Ctrl+C
-- **File**: `Justfile:9-17`
-- **Severity**: low
-- **Fix**: Add `trap "kill $CARGO_PID 2>/dev/null" EXIT INT TERM` after backgrounding cargo
-
-### 3. pick<T>() unsound on empty arrays
-- **File**: `frontend/src/lib/mock.ts:326`
-- **Severity**: nit
-- **Fix**: Add empty-array guard or change return type to `T | undefined`
+## Follow-ups (not blocking)
+- Unit tests for `data-grid.ts` pure functions
+- Tighten `sortStateToConfig` return type
+- Boolean coercion for future SQLite
+- Investigate `aria-sort` on RevoGrid column headers
 
 ## Test Command
 ```bash
-cd frontend && npm run build && cd .. && cargo test
+cd frontend && npm run test && npm run check
 ```
 
 ## Raw Data

--- a/.council/fix-manifest.md
+++ b/.council/fix-manifest.md
@@ -1,72 +1,55 @@
-# Fix Manifest — PR #29: epic: Data Grid & Table Navigation (Session 7)
+# Fix Manifest — PR #29: epic: Data Grid & Table Navigation (Session 8)
 
-Council verdict: **FOR** | 2026-04-10 | 16 findings (16 verified, 16 FIXED) | 1v1 no-questioner | 2 rounds
+Council verdict: **FOR** | 2026-04-10 | Session 8: 4 findings (1 dismissed, 3 tracked, 1 noted) | 1v1 no-questioner | 2 rounds
 
-Prior sessions: Session 1 (3 fixed, 3 dismissed), Session 2 (2 fixed, 1 tracked, 1 dismissed), Session 3 (1 fixed, 1 tracked), Session 4 (1 fixed, 1 tracked), Session 5 (2 fixed, 1 tracked), Session 6 (1 fixed, 2 tracked), Session 7 (1 new finding + 6 previously tracked — all 7 fixed).
+Prior sessions: Sessions 1-7 produced 16 findings, all FIXED. Session 8 is a fresh review of the final code state.
 
-## All Findings Resolved
+## No Pre-Merge Fixes Required
 
-All 16 findings across 7 sessions have been fixed. No tracked or open items remain.
+Session 8 found no pre-merge blockers. All findings are post-merge follow-ups.
 
-## Session 7 Fixes
+## Session 8 Findings
 
-### 1. bigint > 2^53 precision loss in JSON transport
-- **File**: `src/db/postgres.rs:405-408`
-- **Fix**: Serialize bigint as string when `unsigned_abs() > 2^53`; values within safe JS range remain JSON numbers.
+### Dismissed: `get_columns_bulk` PK subquery missing `table_schema`
+- **File**: `src/db/postgres.rs:134-140`
+- **Reason**: ARBITER verified both `get_columns` and `get_columns_bulk` exist on `main` since PR #27 (Epic 1) with identical missing `table_schema` pattern. Pre-existing, not introduced by this PR. CRITIC withdrew.
 
-### 2. Dead currentPage arg in exportCsv
-- **File**: `frontend/src/App.svelte:209`
-- **Fix**: Changed `buildRowsParams(currentPage)` to `buildRowsParams(1)` — page is unused for CSV export.
+### Tracked 1: `formatCellValue` has zero unit tests (medium)
+- **File**: `frontend/src/lib/data-grid.ts:100-174`
+- **Type**: improvement
+- **Fix**: Add `data-grid.test.ts` covering null, boolean, date (T00:00:00 suffix), datetime (space→T), numeric passthrough, NaN/Infinity guard.
 
-### 3. Missing aria-sort on sorted column headers (WCAG 1.3.1)
-- **File**: `frontend/src/components/DataGrid.svelte:66`
-- **Fix**: Added `aria-sort="ascending"`/`"descending"` to header wrapper div via conditional spread.
+### Tracked 2: Content-Disposition non-ASCII filename (low)
+- **File**: `src/api/mod.rs:229-238`
+- **Type**: bug (cosmetic)
+- **Fix**: Add RFC 6266 `filename*=UTF-8''<percent-encoded>` for non-ASCII display names, or strip non-ASCII in sanitizer.
 
-### 4. real (float4) grid vs CSV serialization inconsistency
-- **File**: `src/db/postgres.rs:409-412`
-- **Fix**: Parse f32 via `to_string().parse::<f64>()` to avoid widening artifacts (e.g., 3.14 not 3.140000104904175).
+### Tracked 3: Missing `type="button"` (nit)
+- **Files**: `frontend/src/components/TableList.svelte:43`, `frontend/src/components/StatusBar.svelte:33,41`
+- **Fix**: Add `type="button"` to all three `<button>` elements.
 
-### 5. Dead 'decimal' entry in NUMERIC_TEXT_TYPES
-- **File**: `frontend/src/lib/data-grid.ts:20`
-- **Fix**: Removed — PostgreSQL normalizes DECIMAL to 'numeric'.
+### Noted: ToolStrip `role="status"` live region noisiness
+- **File**: `frontend/src/components/ToolStrip.svelte:57`
+- **Type**: accessibility refinement
+- **Fix**: Consider replacing `role="status"` with `aria-label` on a non-live container to avoid announcing every sort change.
 
-### 6. Content-Disposition missing backslash escape
-- **File**: `src/api/mod.rs:233`
-- **Fix**: Added `.replace('\\', "")` to filename sanitizer chain.
+## Cumulative History (sessions 1-7)
 
-### 7. Search ILIKE path skips identifier validation on schema-derived column names
-- **File**: `src/db/postgres.rs:211`
-- **Fix**: Added `&& is_valid_identifier(&c.name)` to the `text_cols` filter chain.
+All 16 findings from sessions 1-7 are FIXED:
+- Session 1: Date off-by-one, timestamp year omission, ToolStrip ARIA role
+- Session 2: Safari Invalid Date, CSV export ignores filters/sort
+- Session 3: numeric/decimal precision loss via Number() cast
+- Session 4: real (float4) OID mismatch, missing aria-sort on headers
+- Session 5: Boolean filter mapping, numeric display classification
+- Session 6: ToolStrip export aria-label misinformation, dead 'decimal' entry, Content-Disposition backslash
+- Session 7: Search ILIKE identifier validation, bigint > 2^53 serialization, dead currentPage arg, + 4 tracked fixes
 
-## Prior Session Fixes (sessions 1-6)
-
-### Session 1
-1. **Date off-by-one for non-UTC users** — `data-grid.ts`: separate DATE_ONLY_TYPES, append T00:00:00
-2. **Timestamp formatter omits year** — `data-grid.ts`: added year: 'numeric' to Intl.DateTimeFormat
-3. **ToolStrip sort indicator missing ARIA role** — `ToolStrip.svelte`: added role="status"
-
-### Session 2
-1. **Safari Invalid Date for `timestamp without time zone`** — `data-grid.ts:137`: replace space with T
-2. **CSV export ignores active filters/sort** — `App.svelte:207-219`: pass sort/filter params to export URL
-
-### Session 3
-1. **numeric/decimal precision loss via Number() cast** — `data-grid.ts:14-15`: removed numeric/decimal from NUMBER_TYPES
-
-### Session 4
-1. **real (float4) columns silently null out via OID mismatch** — `postgres.rs:386-389`: split real/double precision arms
-
-### Session 5
-1. **Boolean filter broken: Yes/No display vs true/false SQL cast** — `postgres.rs:221-248`: use = TRUE/FALSE instead of ::text ILIKE
-2. **numeric/decimal columns display as left-aligned plain text** — `data-grid.ts:16-21, 152-157`: added NUMERIC_TEXT_TYPES set
-
-### Session 6
-1. **ToolStrip export aria-label misinforms users** — `ToolStrip.svelte:83-85`: changed to "More export options coming soon"
-
-## Dismissed (sessions 1-6)
-- `on:beforesorting` Svelte 5 syntax — correct for Svelte 4 dispatcher consumed by Svelte 5
+## Dismissed Across All Sessions
+- `on:beforesorting` Svelte 5 syntax — correct for Svelte 4 dispatcher
 - Boolean coercion misses 1/yes/on — backend sends JSON booleans only
 - ILIKE performance on 500K rows — pre-existing design choice
 - sortStateToConfig returns undefined — sort indicators driven by per-column `order` prop
+- get_columns_bulk schema filter — pre-existing on main since Epic 1
 
 ## Test Command
 ```bash

--- a/.council/fix-manifest.md
+++ b/.council/fix-manifest.md
@@ -1,16 +1,16 @@
-# Fix Manifest — PR #29: epic: Data Grid & Table Navigation (Session 3)
+# Fix Manifest — PR #29: epic: Data Grid & Table Navigation (Session 4)
 
-Council verdict: **CONDITIONAL→FOR** | 2026-04-09 | 7 findings (7 verified) | 1v1 no-questioner | 2 rounds
+Council verdict: **CONDITIONAL→FOR** | 2026-04-09 | 9 findings (9 verified) | 1v1 no-questioner | 2 rounds
 
-Prior sessions: Session 1 (3 findings, all fixed, 3 dismissed), Session 2 (2 fixed, 1 tracked, 1 dismissed).
+Prior sessions: Session 1 (3 fixed, 3 dismissed), Session 2 (2 fixed, 1 tracked, 1 dismissed), Session 3 (1 fixed, 1 tracked).
 
-## Session 3 Fix (applied in this commit)
+## Session 4 Fix (applied in this commit)
 
-### 1. numeric/decimal precision loss via Number() cast
-- **File**: `frontend/src/lib/data-grid.ts:14-15`
+### 1. real (float4) columns silently null out via try_get::\<f64\> OID mismatch
+- **File**: `src/db/postgres.rs:386-389`, `src/api/mod.rs:378-381`
 - **Severity**: high
-- **Fix**: Removed `'numeric'` and `'decimal'` from `NUMBER_TYPES`. Backend already sends full-precision string (`postgres.rs:391`); values now fall through to the text formatter at `data-grid.ts:158-161`.
-- **Conceded by**: ADVOCATE (partially — agreed bug is real, contested blocking status)
+- **Fix**: Split `"real" | "double precision"` arm — use `try_get::<f32>` for `real` (OID 700), keep `try_get::<f64>` for `double precision` (OID 701). Applied in both `pg_value_to_json` and `pg_value_to_csv_string`.
+- **Conceded by**: ADVOCATE (full concession after arbiter verified sqlx source)
 
 ## Prior Session Fixes
 
@@ -22,6 +22,9 @@ Prior sessions: Session 1 (3 findings, all fixed, 3 dismissed), Session 2 (2 fix
 ### Session 2
 1. **Safari Invalid Date for `timestamp without time zone`** — `data-grid.ts:137`: replace space with T
 2. **CSV export ignores active filters/sort** — `App.svelte:207-219`: pass sort/filter params to export URL
+
+### Session 3
+1. **numeric/decimal precision loss via Number() cast** — `data-grid.ts:14-15`: removed numeric/decimal from NUMBER_TYPES
 
 ## Tracked (post-merge, not blocking)
 
@@ -35,7 +38,12 @@ Prior sessions: Session 1 (3 findings, all fixed, 3 dismissed), Session 2 (2 fix
 - **Severity**: nit
 - **Fix**: Remove unused page param from `buildRowsParams` call in `exportCsv`
 
-## Dismissed (sessions 1-2)
+### 3. Missing aria-sort on sorted column headers (WCAG 1.3.1)
+- **File**: `frontend/src/components/DataGrid.svelte:66-100`
+- **Severity**: medium
+- **Fix**: Add `aria-sort="ascending"` / `"descending"` to header div in renderHeader. May require inspecting RevoGrid's rendered DOM to target the actual `<th>`.
+
+## Dismissed (sessions 1-3)
 - `on:beforesorting` Svelte 5 syntax — correct for Svelte 4 dispatcher consumed by Svelte 5
 - Boolean coercion misses 1/yes/on — backend sends JSON booleans only
 - ILIKE performance on 500K rows — pre-existing design choice

--- a/.council/fix-manifest.md
+++ b/.council/fix-manifest.md
@@ -1,22 +1,16 @@
-# Fix Manifest — PR #29: epic: Data Grid & Table Navigation (Session 5)
+# Fix Manifest — PR #29: epic: Data Grid & Table Navigation (Session 6)
 
-Council verdict: **CONDITIONAL→FOR** | 2026-04-09 | 12 findings (12 verified) | 1v1 no-questioner | 2 rounds
+Council verdict: **FOR** | 2026-04-09 | 15 findings (15 verified) | 1v1 no-questioner | 2 rounds
 
-Prior sessions: Session 1 (3 fixed, 3 dismissed), Session 2 (2 fixed, 1 tracked, 1 dismissed), Session 3 (1 fixed, 1 tracked), Session 4 (1 fixed, 1 tracked).
+Prior sessions: Session 1 (3 fixed, 3 dismissed), Session 2 (2 fixed, 1 tracked, 1 dismissed), Session 3 (1 fixed, 1 tracked), Session 4 (1 fixed, 1 tracked), Session 5 (2 fixed, 1 tracked).
 
-## Session 5 Fixes (applied in this commit)
+## Session 6 Fixes (applied in this commit)
 
-### 1. Boolean filter broken: Yes/No display vs true/false SQL cast
-- **File**: `src/db/postgres.rs:221-248`
-- **Severity**: high
-- **Fix**: Boolean columns now use `= TRUE`/`= FALSE` comparison instead of `::text ILIKE`. Filter input mapped: yes/true/t/1 → TRUE, no/false/f/0 → FALSE. Non-matching input yields no rows.
-- **Conceded by**: ADVOCATE (full concession — violates "no visible SQL" design principle)
-
-### 2. numeric/decimal columns display as left-aligned plain text
-- **File**: `frontend/src/lib/data-grid.ts:16-21, 152-157`
+### 1. ToolStrip export aria-label misinforms users
+- **File**: `frontend/src/components/ToolStrip.svelte:83-85`
 - **Severity**: medium
-- **Fix**: Added `NUMERIC_TEXT_TYPES` set for 'numeric'/'decimal'. Returns `kind: 'number'` with raw string display (no Number() cast), giving right-alignment and tabular-nums without precision loss.
-- **Conceded by**: ADVOCATE (display regression from Session 3 precision fix)
+- **Fix**: Changed `aria-label="Export tools coming later"` to `"More export options coming soon"` — disambiguates from the existing working CSV export in the Toolbar.
+- **Conceded by**: ADVOCATE (full concession — factually incorrect accessible text)
 
 ## Prior Session Fixes
 
@@ -34,6 +28,10 @@ Prior sessions: Session 1 (3 fixed, 3 dismissed), Session 2 (2 fixed, 1 tracked,
 
 ### Session 4
 1. **real (float4) columns silently null out via OID mismatch** — `postgres.rs:386-389`: split real/double precision arms
+
+### Session 5
+1. **Boolean filter broken: Yes/No display vs true/false SQL cast** — `postgres.rs:221-248`: use = TRUE/FALSE instead of ::text ILIKE
+2. **numeric/decimal columns display as left-aligned plain text** — `data-grid.ts:16-21, 152-157`: added NUMERIC_TEXT_TYPES set
 
 ## Tracked (post-merge, not blocking)
 
@@ -56,6 +54,16 @@ Prior sessions: Session 1 (3 fixed, 3 dismissed), Session 2 (2 fixed, 1 tracked,
 - **File**: `src/db/postgres.rs:388`, `src/api/mod.rs:380`
 - **Severity**: low
 - **Fix**: Use `f32.to_string()` then parse for JSON instead of `f32 as f64` widening
+
+### 5. Dead 'decimal' entry in NUMERIC_TEXT_TYPES
+- **File**: `frontend/src/lib/data-grid.ts:20`
+- **Severity**: nit
+- **Fix**: Remove the entry — PostgreSQL normalizes DECIMAL to 'numeric'
+
+### 6. Content-Disposition missing backslash escape
+- **File**: `src/api/mod.rs:235`
+- **Severity**: nit
+- **Fix**: Add `.replace('\\', "")` to filename sanitizer chain
 
 ## Dismissed (sessions 1-4)
 - `on:beforesorting` Svelte 5 syntax — correct for Svelte 4 dispatcher consumed by Svelte 5

--- a/.council/fix-manifest.md
+++ b/.council/fix-manifest.md
@@ -1,51 +1,47 @@
-# Fix Manifest — PR #29: epic: Data Grid & Table Navigation
+# Fix Manifest — PR #29: epic: Data Grid & Table Navigation (Session 2)
 
-Council verdict: **CONDITIONAL** | 2026-04-09 | 3 findings (3 verified)
+Council verdict: **FOR** | 2026-04-09 | 4 findings (4 verified, 1 dismissed) | 1v1 no-questioner | 2 rounds
 
-## Fixes Required
+Prior session: Session 1 (3 findings, all fixed, 3 dismissed).
 
-### 1. Date off-by-one for non-UTC users
-- **File**: `frontend/src/lib/data-grid.ts`
-- **Line**: 111
-- **Type**: bug
+## No Fixes Required (pre-merge)
+
+All pre-merge issues from sessions 1+2 have been resolved.
+
+### Session 1 Fixes (applied in prior commit)
+
+1. **Date off-by-one for non-UTC users** — `data-grid.ts`: separate DATE_ONLY_TYPES, append T00:00:00, use dateFormatter
+2. **Timestamp formatter omits year** — `data-grid.ts`: added year: 'numeric' to Intl.DateTimeFormat
+3. **ToolStrip sort indicator missing ARIA role** — `ToolStrip.svelte`: added role="status"
+
+### Session 2 Fixes (applied in this commit)
+
+#### 1. Safari Invalid Date for `timestamp without time zone`
+- **File**: `frontend/src/lib/data-grid.ts:137`
 - **Severity**: high
-- **Verification**: verified
-- **Fix**: Detect date-only columns (`column.data_type === 'date'`) and either:
-  (a) Append `'T00:00:00'` to force local-timezone parsing, or
-  (b) Use a separate date-only `Intl.DateTimeFormat` (no hour/minute) for `date` columns.
-  Date columns should NOT show time components in the display.
-- **Citations**: `data-grid.ts:111`, `data-grid.ts:18-23`, `postgres.rs:408-411`
+- **Fix**: Replace space with T before `new Date()` — `new Date(raw.replace(' ', 'T'))`
+- **Conceded by**: ADVOCATE
 
-### 2. Timestamp formatter omits year
-- **File**: `frontend/src/lib/data-grid.ts`
-- **Line**: 25
-- **Type**: bug
+#### 2. CSV export ignores active filters/sort
+- **File**: `frontend/src/App.svelte:207-219`
 - **Severity**: medium
-- **Verification**: verified
-- **Fix**: Add `year: 'numeric'` to the `Intl.DateTimeFormat` options at lines 25-30.
-- **Citations**: `data-grid.ts:25-30`
+- **Fix**: Pass `buildRowsParams()` as query params to the export URL
+- **Conceded by**: ADVOCATE
 
-### 3. ToolStrip sort indicator missing ARIA role
-- **File**: `frontend/src/components/ToolStrip.svelte`
-- **Line**: 57
-- **Type**: improvement
+### Dismissed: sortStateToConfig returns undefined
+- **Claim**: RevoGrid sort indicators not cleared when `sorting` is `undefined`
+- **Reason**: ADVOCATE rebutted — sort indicators driven by per-column `order` prop (`DataGrid.svelte:198-199`), not `sorting` object prop
+
+## Tracked (post-merge, not blocking)
+
+### 1. is_valid_identifier rejects hyphenated identifiers
+- **File**: `src/db/postgres.rs:169-171`
 - **Severity**: medium
-- **Verification**: verified
-- **Fix**: Add `role="status"` to the sort indicator `<div>` element.
-- **Citations**: `ToolStrip.svelte:57`
-
-## Conditions
-- All 3 fixes must be applied before merge
-
-## Follow-ups (not blocking)
-- Unit tests for `data-grid.ts` pure functions
-- Tighten `sortStateToConfig` return type
-- Boolean coercion for future SQLite
-- Investigate `aria-sort` on RevoGrid column headers
+- **Fix**: Add hyphen to the identifier allowlist (safe inside double-quotes)
 
 ## Test Command
 ```bash
-cd frontend && npm run test && npm run check
+cd frontend && npm run check && cd .. && cargo test
 ```
 
 ## Raw Data

--- a/.council/fix-manifest.md
+++ b/.council/fix-manifest.md
@@ -1,16 +1,22 @@
-# Fix Manifest — PR #29: epic: Data Grid & Table Navigation (Session 4)
+# Fix Manifest — PR #29: epic: Data Grid & Table Navigation (Session 5)
 
-Council verdict: **CONDITIONAL→FOR** | 2026-04-09 | 9 findings (9 verified) | 1v1 no-questioner | 2 rounds
+Council verdict: **CONDITIONAL→FOR** | 2026-04-09 | 12 findings (12 verified) | 1v1 no-questioner | 2 rounds
 
-Prior sessions: Session 1 (3 fixed, 3 dismissed), Session 2 (2 fixed, 1 tracked, 1 dismissed), Session 3 (1 fixed, 1 tracked).
+Prior sessions: Session 1 (3 fixed, 3 dismissed), Session 2 (2 fixed, 1 tracked, 1 dismissed), Session 3 (1 fixed, 1 tracked), Session 4 (1 fixed, 1 tracked).
 
-## Session 4 Fix (applied in this commit)
+## Session 5 Fixes (applied in this commit)
 
-### 1. real (float4) columns silently null out via try_get::\<f64\> OID mismatch
-- **File**: `src/db/postgres.rs:386-389`, `src/api/mod.rs:378-381`
+### 1. Boolean filter broken: Yes/No display vs true/false SQL cast
+- **File**: `src/db/postgres.rs:221-248`
 - **Severity**: high
-- **Fix**: Split `"real" | "double precision"` arm — use `try_get::<f32>` for `real` (OID 700), keep `try_get::<f64>` for `double precision` (OID 701). Applied in both `pg_value_to_json` and `pg_value_to_csv_string`.
-- **Conceded by**: ADVOCATE (full concession after arbiter verified sqlx source)
+- **Fix**: Boolean columns now use `= TRUE`/`= FALSE` comparison instead of `::text ILIKE`. Filter input mapped: yes/true/t/1 → TRUE, no/false/f/0 → FALSE. Non-matching input yields no rows.
+- **Conceded by**: ADVOCATE (full concession — violates "no visible SQL" design principle)
+
+### 2. numeric/decimal columns display as left-aligned plain text
+- **File**: `frontend/src/lib/data-grid.ts:16-21, 152-157`
+- **Severity**: medium
+- **Fix**: Added `NUMERIC_TEXT_TYPES` set for 'numeric'/'decimal'. Returns `kind: 'number'` with raw string display (no Number() cast), giving right-alignment and tabular-nums without precision loss.
+- **Conceded by**: ADVOCATE (display regression from Session 3 precision fix)
 
 ## Prior Session Fixes
 
@@ -25,6 +31,9 @@ Prior sessions: Session 1 (3 fixed, 3 dismissed), Session 2 (2 fixed, 1 tracked,
 
 ### Session 3
 1. **numeric/decimal precision loss via Number() cast** — `data-grid.ts:14-15`: removed numeric/decimal from NUMBER_TYPES
+
+### Session 4
+1. **real (float4) columns silently null out via OID mismatch** — `postgres.rs:386-389`: split real/double precision arms
 
 ## Tracked (post-merge, not blocking)
 
@@ -41,9 +50,14 @@ Prior sessions: Session 1 (3 fixed, 3 dismissed), Session 2 (2 fixed, 1 tracked,
 ### 3. Missing aria-sort on sorted column headers (WCAG 1.3.1)
 - **File**: `frontend/src/components/DataGrid.svelte:66-100`
 - **Severity**: medium
-- **Fix**: Add `aria-sort="ascending"` / `"descending"` to header div in renderHeader. May require inspecting RevoGrid's rendered DOM to target the actual `<th>`.
+- **Fix**: Add `aria-sort="ascending"` / `"descending"` to header div in renderHeader
 
-## Dismissed (sessions 1-3)
+### 4. real (float4) grid vs CSV serialization inconsistency
+- **File**: `src/db/postgres.rs:388`, `src/api/mod.rs:380`
+- **Severity**: low
+- **Fix**: Use `f32.to_string()` then parse for JSON instead of `f32 as f64` widening
+
+## Dismissed (sessions 1-4)
 - `on:beforesorting` Svelte 5 syntax — correct for Svelte 4 dispatcher consumed by Svelte 5
 - Boolean coercion misses 1/yes/on — backend sends JSON booleans only
 - ILIKE performance on 500K rows — pre-existing design choice

--- a/2026-04-08-council-merge-epic-1-into-main.md
+++ b/2026-04-08-council-merge-epic-1-into-main.md
@@ -1,0 +1,47 @@
+## Adversarial Council — Merge epic/1-backend-api-config into main
+
+> Convened: 2026-04-08 | Advocates: 1 | Critics: 1 | Rounds: 3/4 | Motion type: CODE
+
+### Motion
+Merge the epic/1-backend-api-config branch into main. This branch adds backend API endpoints, config extensions, setup wizard, CSV export, and database hardening to the SeeKi project.
+
+### Advocate Positions
+**ADVOCATE**: The branch delivers real features (config extensions, display config endpoint, setup wizard, CSV export, table filtering), has fixed both prior blocking findings per the fix manifest (u32 OFFSET overflow at `src/db/postgres.rs:287`, invalid CSV sentinel removed at `src/api/mod.rs:302-317`), maintains the SQL injection prevention invariant (identifier validation at `src/db/postgres.rs:169-171`, parameterized queries at `src/db/postgres.rs:281-296`), enforces table access control on all table-scoped endpoints (`src/api/mod.rs:119,178,205`), hardens the setup wizard against TOML injection and blind writes (`src/api/setup.rs:120-184`), and includes 34+ unit and integration tests across all new paths. The prior council's exit criteria are met.
+
+### Critic Positions
+**CRITIC**: Raised three gaps. (1) `save_config` success path at `src/api/setup.rs:187` has no end-to-end test — all five tests in the module are rejection tests. (2) CSV export delivers silently truncated data with `200 OK` on mid-stream errors (`src/api/mod.rs:315-317`) — non-technical users receive incomplete data with no signal. (3) CORS prefix matching at `src/main.rs:47` matches broader origins than intended. CRITIC ultimately conceded all three as non-blocking: Gap 3 on scope grounds (fix manifest classified it as informational), Gap 1 on indirect coverage (component functions are tested, integration test gap is pre-existing infrastructure constraint), Gap 2 on prior mandate (fix manifest explicitly chose option (a) knowing the tradeoff).
+
+### Questioner Findings
+No questioner in this council (1v1 format).
+
+### Key Conflicts
+- **save_config test coverage** — CRITIC argued the success path is "completely untested"; ADVOCATE showed indirect coverage via `AppConfig::parse` tests in `src/config.rs` (18 tests including `minimal_config_loads_with_defaults` at L264 which covers the exact TOML shape `save_config` emits). CRITIC narrowed the finding to "lower severity" and ultimately conceded it is not proportionate to block given the pre-existing integration test infrastructure gap. **Resolved: not blocking.**
+- **CSV silent truncation** — CRITIC argued silent truncation is a functional defect for non-technical users; ADVOCATE cited the fix manifest's explicit choice of option (a) ("a truncated CSV is less harmful than a corrupted one") as the governing exit criterion. CRITIC conceded this was a new requirement beyond the prior mandate, not a defect against it. **Resolved: not blocking, recommended as follow-up.**
+- **CORS prefix matching** — CRITIC framed it as a manifest-prescribed fix left unaddressed; ARBITER challenged this citing `.council/fix-manifest.md:29` which classifies it as "informational (not blocking), low severity for localhost tool." CRITIC conceded immediately. **Resolved: not blocking.**
+
+### Concessions
+- **CRITIC** conceded Gap 3 (CORS) to **ARBITER** — fix manifest explicitly classified as non-blocking informational
+- **CRITIC** conceded Gap 1 (save_config test coverage) to **ADVOCATE** — indirect coverage is substantial, integration test gap is pre-existing infrastructure constraint
+- **CRITIC** conceded Gap 2 (CSV truncation) to **ADVOCATE** — prior council explicitly chose this tradeoff and defined the exit criterion; new requirement was outside the mandate
+- **ADVOCATE** conceded that from a UX perspective, silent CSV truncation is "a genuine problem" for non-technical users — but classified it as a follow-up, not a blocker
+
+### Regression Lineage
+No regression lineage — no prior fix involvement. The two blocking findings from the prior council (`fix-manifest.md:10-16` u32 overflow, `fix-manifest.md:18-26` CSV sentinel) are both verified fixed.
+
+### Arbiter Recommendation
+**FOR**
+
+The branch meets all exit criteria defined by the prior council's fix manifest. Both blocking findings are verified fixed with correct implementations. CRITIC raised three gaps, all of which were either conceded or resolved through debate. The branch maintains the SQL injection prevention invariant documented in CLAUDE.md, enforces table access control on every table-scoped endpoint, hardens the setup wizard against injection and blind writes, and includes substantive test coverage (34+ tests across config, API, setup, and DB modules). No unresolved blocking findings remain.
+
+### Conditions (if CONDITIONAL)
+None — recommendation is FOR without conditions.
+
+### Suggested Fixes
+No issues identified that require in-PR fixes. All prior blocking findings are already fixed.
+
+### Follow-Up Recommendations (non-blocking)
+These items were raised during the debate and acknowledged by both sides as real but non-blocking concerns:
+
+1. **CSV truncation UX** — Track as a follow-up issue: add a client-detectable signal for truncated CSV exports (e.g., trailing comment row in valid CSV format, or a non-streaming fallback endpoint with explicit error). Acknowledged by ADVOCATE as "a genuine UX problem" for non-technical users.
+2. **save_config integration test** — When live-DB test infrastructure is established for the project, add an end-to-end test for the `save_config` success path at `src/api/setup.rs:187`.
+3. **CORS exact matching** — Per fix manifest informational note: tighten `src/main.rs:47` from `starts_with("http://localhost")` to `s == "http://localhost" || s.starts_with("http://localhost:")`. Low severity, zero-cost fix.

--- a/data-grid-table-navigation-spec.md
+++ b/data-grid-table-navigation-spec.md
@@ -1,0 +1,290 @@
+# Feature: Data Grid & Table Navigation (Epic 3)
+
+## Overview
+
+**User Story**: As a non-technical database user, I want a spreadsheet-like grid with sorting, filtering, and type-aware formatting so that I can explore large datasets without writing SQL or using DBeaver.
+
+**Problem**: The current frontend renders raw data in a bare grid — no sort indicators, no column filters, no display formatting (timestamps show as ISO strings, booleans as `true`/`false`, NULLs as blank). Users cannot narrow results or understand data types at a glance. The sidebar table list has no search, making navigation painful with 20+ tables.
+
+**Out of Scope**:
+- Multi-column sort (single column only for MVP)
+- Client-side data caching or optimistic updates
+- Column reordering or resizing (RevoGrid default resizing is acceptable)
+- Global search wiring (Epic 4 — Toolbar)
+- Column hide/show (Epic 4)
+- CSV export button (Epic 4)
+- Setup wizard (Epic 5)
+
+---
+
+## Success Condition
+
+> This feature is complete when a user can select a table from a searchable sidebar, view data in a virtualized grid with type-aware formatting, click column headers to sort (server-side), toggle per-column text filters from a left tool strip, and paginate through results — all working in both mock mode and against a live PostgreSQL database.
+
+---
+
+## Open Questions
+
+| # | Question | Raised By | Resolved |
+|:--|:---------|:----------|:---------|
+| 1 | RevoGrid `columnTemplate` vs custom header overlay for sort/filter UI — need to verify RevoGrid 4.x Svelte 5 template API | Brainstorm | [x] Resolved: `columnTemplate(h, props)` returns VNodes via hyperscript; `cellTemplate(h, { value })` for cell formatting; `beforesorting` event supports `preventDefault()`. All confirmed via Context7 docs. |
+
+---
+
+## Scope
+
+### Must-Have
+
+- **RevoGrid as dumb renderer**: Disable built-in sort/filter; use `readonly` prop; CSS flex height cascade for virtualization (T9 / #17)
+  - *Acceptance*: Grid renders 50 rows with virtual scrolling active; no built-in RevoGrid sort/filter UI visible
+- **Click-to-sort columns**: Three-state cycle (asc -> desc -> unsorted) on column headers; single column at a time; chevron indicator on active column; server-side sort via `sort_column`/`sort_direction` params (T11 / #18)
+  - *Acceptance*: Clicking a column header cycles through asc/desc/unsorted; sort chevron visible on active column; data re-fetches from server with correct params
+- **Per-column text filters**: Filter inputs inside header cells, hidden by default; toggle via funnel icon in left tool strip; 300ms debounce; AND logic across columns; active filter count badge on funnel icon when filters hidden (T12 / #19)
+  - *Acceptance*: Toggling filter shows input in each column header; typing triggers debounced server fetch with `filter.{col}` params; multiple filters combine with AND; badge shows count when collapsed
+- **Display formatting**: Type-aware cell renderers for timestamps, booleans, numbers, NULLs (T13 / #20)
+  - *Acceptance*: Timestamps show "Apr 7, 3:58 PM" with full ISO tooltip; booleans render as colored badges (green "Yes" / red "No"); numbers are locale-formatted; NULLs show dim italic "NULL" text on hatched background
+- **Sidebar table search**: Client-side text filter input at top of table list, case-insensitive match against display name (T8 / #16)
+  - *Acceptance*: Typing in search box filters table list instantly; clearing restores full list
+- **Status bar verification**: Confirm existing status bar meets acceptance criteria — "Showing X-Y of N" with working pagination (T16 / #21)
+  - *Acceptance*: Status bar shows correct counts; prev/next buttons work; disabled at boundaries
+- **Left vertical tool strip** (new component): ~36-40px wide icon strip between sidebar and grid; top section for data manipulation tools (filter toggle, sort indicator); bottom section reserved for future utility tools (export, column visibility); visual separator between sections; icon buttons with tooltips
+  - *Acceptance*: Tool strip renders between sidebar and grid area; funnel icon toggles filter row; sort state visible; tooltips on hover
+
+### Should-Have
+
+- **Mock filter support**: Extend `mock.ts` to support `filter.{col}` params so filter UI works in `VITE_MOCK=true` mode
+- **Keyboard shortcut for filter toggle**: `Ctrl+F` / `Cmd+F` to toggle filter row visibility
+
+### Nice-to-Have
+
+- **Clear all filters button**: Single action to reset all active column filters
+- **Sort indicator in tool strip**: Small label or icon showing current sort column and direction
+
+---
+
+## Technical Plan
+
+**Affected Components**:
+
+| File | Change |
+|:-----|:-------|
+| `frontend/src/App.svelte` | Add ToolStrip to layout; wire sort/filter state; pass callbacks down |
+| `frontend/src/components/DataGrid.svelte` | Major rework — `columnTemplate(h, props)` for custom headers (sort chevrons + filter inputs); `cellTemplate(h, { value })` for display formatting; `beforesorting` event with `preventDefault()` to block built-in sort |
+| `frontend/src/components/ToolStrip.svelte` | **New** — vertical icon strip with filter toggle, sort indicator |
+| `frontend/src/components/Sidebar.svelte` | No change (already done) |
+| `frontend/src/components/TableList.svelte` | Add search input prop and filtering logic |
+| `frontend/src/components/StatusBar.svelte` | Verify only — likely no changes |
+| `frontend/src/components/Toolbar.svelte` | Remove filter/sort responsibilities (moved to ToolStrip); may simplify |
+| `frontend/src/lib/api.ts` | No change — `fetchRows` already supports all needed params |
+| `frontend/src/lib/mock.ts` | Add per-column filter support to `mockFetchRows` |
+| `frontend/src/lib/types.ts` | Add `SortState` and `FilterState` types |
+| `frontend/src/theme/tokens.css` | Add `--sk-null-hatch` pattern, any tool strip tokens |
+
+**Data Model Changes**: None — backend API already supports all required params.
+
+**API Contracts**: No new endpoints. Existing endpoints used:
+- `GET /api/tables/{table}/rows?sort_column=X&sort_direction=asc|desc&filter.{col}=value&page=N` — already implemented
+- Sort/filter params already validated server-side with identifier validation
+
+**Dependencies**:
+- `@revolist/svelte-datagrid` ^4.21.4 (already installed)
+- `lucide-svelte` (already installed — icons: `Filter`, `ArrowUpDown`, `ChevronUp`, `ChevronDown`)
+- No new packages required
+
+**Risks**:
+
+| Risk | Likelihood | Mitigation |
+|:-----|:-----------|:-----------|
+| RevoGrid Svelte 5 `columnTemplate` API is undocumented or broken | Low (verified via Context7 docs — hyperscript `h` function works) | Fallback: render custom header row outside RevoGrid as an overlay div, position-synced with grid scroll |
+| CSS height cascade doesn't trigger RevoGrid virtualization | Low | Fallback: ResizeObserver to set explicit pixel height on grid container |
+| RevoGrid intercepts header clicks despite `readonly` | Low | Use `beforesorting` event with `preventDefault()` as additional guard |
+
+---
+
+## Acceptance Scenarios
+
+```gherkin
+Feature: Data Grid & Table Navigation
+  As a non-technical database user
+  I want a spreadsheet-like grid with sorting, filtering, and formatting
+  So that I can explore large datasets without SQL
+
+  Background:
+    Given the app is loaded with mock data (VITE_MOCK=true)
+    And the "Users" table is selected
+
+  Rule: Grid renders data with virtual scrolling
+
+    Scenario: Initial grid load
+      Given the "Users" table has 42 rows
+      When the grid renders
+      Then 42 rows are displayed across pages
+      And RevoGrid virtual scrolling is active (DOM contains fewer elements than total rows)
+      And column headers show display names from config
+
+    Scenario: Grid fills available height
+      Given the browser window is 900px tall
+      When the sidebar is collapsed
+      Then the grid expands to fill the main area height
+      And no unnecessary scrollbars appear on the page body
+
+  Rule: Click-to-sort cycles through three states
+
+    Scenario: Sort ascending on first click
+      Given no column is currently sorted
+      When I click the "Name" column header
+      Then the grid re-fetches with sort_column=name and sort_direction=asc
+      And an upward chevron appears on the "Name" header
+
+    Scenario: Sort descending on second click
+      Given the "Name" column is sorted ascending
+      When I click the "Name" column header again
+      Then the grid re-fetches with sort_column=name and sort_direction=desc
+      And a downward chevron appears on the "Name" header
+
+    Scenario: Clear sort on third click
+      Given the "Name" column is sorted descending
+      When I click the "Name" column header again
+      Then the grid re-fetches with no sort params
+      And no sort chevron appears on any header
+
+    Scenario: Sorting a different column replaces current sort
+      Given the "Name" column is sorted ascending
+      When I click the "Email" column header
+      Then the grid re-fetches with sort_column=email and sort_direction=asc
+      And the chevron moves from "Name" to "Email"
+
+  Rule: Per-column filters are toggleable and debounced
+
+    Scenario: Toggle filter visibility
+      Given filters are hidden (default state)
+      When I click the filter icon in the tool strip
+      Then a text input appears inside each column header
+      And the filter icon shows an active state
+
+    Scenario: Typing a filter triggers debounced fetch
+      Given filters are visible
+      When I type "alice" in the "Name" filter input
+      And I wait 300ms
+      Then the grid re-fetches with filter.name=alice
+      And the results show only rows matching "alice" in the Name column
+
+    Scenario: Multiple filters combine with AND logic
+      Given I have filter.name=alice active
+      When I type "active" in the "Status" filter input and wait 300ms
+      Then the grid re-fetches with filter.name=alice AND filter.status=active
+      And only rows matching both filters are shown
+
+    Scenario: Active filter count badge
+      Given 2 column filters are active
+      When I hide the filter row via the tool strip icon
+      Then the funnel icon shows a "2" badge
+      And filters remain active (data is still filtered)
+
+    Scenario: Clearing a filter re-fetches without it
+      Given filter.name=alice is active
+      When I clear the "Name" filter input and wait 300ms
+      Then the grid re-fetches without the name filter
+
+  Rule: Cells render with type-aware formatting
+
+    Scenario Outline: Display formatting by data type
+      Given a cell contains <raw_value> with data_type <type>
+      When the grid renders
+      Then the cell displays <formatted>
+      And <tooltip_behaviour>
+
+      Examples:
+        | type                         | raw_value                 | formatted         | tooltip_behaviour                        |
+        | timestamp without time zone  | 2026-04-07T15:58:00      | Apr 7, 3:58 PM    | hover shows "2026-04-07T15:58:00"        |
+        | boolean                      | true                     | green "Yes" badge  | no tooltip                               |
+        | boolean                      | false                    | red "No" badge     | no tooltip                               |
+        | integer                      | 1234567                  | 1,234,567          | no tooltip                               |
+        | numeric                      | 1234567.89               | 1,234,567.89       | no tooltip                               |
+        | null (any type)              | null                     | italic "NULL" on hatched bg | no tooltip                      |
+
+  Rule: Sidebar table list is searchable
+
+    Scenario: Filter table list by typing
+      Given 5 tables are loaded in the sidebar
+      When I type "act" in the table search input
+      Then only tables with "act" in their display name are shown (e.g., "Activity Log")
+
+    Scenario: Clearing search restores full list
+      Given the table search input contains "act"
+      When I clear the input
+      Then all 5 tables are shown
+
+  Rule: Status bar shows correct pagination info
+
+    Scenario: Status bar reflects current page
+      Given the "Activity Log" table has 200 rows with page_size 50
+      When page 1 is loaded
+      Then the status bar shows "Showing 1 - 50 of 200"
+      And "1 of 4" page indicator is visible
+
+    Scenario: Pagination buttons at boundaries
+      Given I am on page 1 of 4
+      Then the "Previous" button is disabled
+      And the "Next" button is enabled
+
+  Rule: Tool strip provides data manipulation controls
+
+    Scenario: Tool strip renders with filter toggle
+      When the app loads
+      Then a vertical tool strip appears between the sidebar and grid
+      And it contains a funnel icon button with tooltip "Toggle filters"
+
+    Scenario: Tool strip sort indicator shows current state
+      Given the "Name" column is sorted ascending
+      Then the tool strip shows a sort indicator reflecting "Name asc"
+```
+
+---
+
+## Task Breakdown
+
+| ID | Task | Issue | Branch | Priority | Dependencies | Status |
+|:---|:-----|:------|:-------|:---------|:-------------|:-------|
+| T9 | RevoGrid dumb renderer: disable built-in interactions, CSS height cascade, verify virtual scrolling | #17 | `feature/17-*` | High | None | pending |
+| T9.1 | Add `SortState`, `FilterState` types to `types.ts` | #17 | `feature/17-*` | High | None | pending |
+| T9.2 | Create `ToolStrip.svelte` component shell with layout slots | — | `feature/17-*` | High | None | pending |
+| T9.3 | Wire ToolStrip into `App.svelte` layout (sidebar | toolstrip | main) | — | `feature/17-*` | High | T9.2 | pending |
+| T11 | Click-to-sort: header click handler, three-state cycle, chevron indicators | #18 | `feature/18-*` | High | T9 | pending |
+| T11.1 | Wire sort state in App.svelte, pass to DataGrid and ToolStrip | #18 | `feature/18-*` | High | T9.3, T11 | pending |
+| T12 | Per-column filter UI: inputs inside headers, toggle visibility | #19 | `feature/19-*` | High | T11 | pending |
+| T12.1 | Filter debounce logic (300ms) and API wiring in App.svelte | #19 | `feature/19-*` | High | T12 | pending |
+| T12.2 | Active filter count badge on ToolStrip funnel icon | #19 | `feature/19-*` | High | T12.1 | pending |
+| T12.3 | Add per-column filter support to `mock.ts` | #19 | `feature/19-*` | Med | T12 | pending |
+| T13 | Cell formatters: timestamp, boolean badge, number locale, NULL hatched | #20 | `feature/20-*` | High | T9 | pending |
+| T8 | Sidebar table search: text input + client-side filter in TableList | #16 | `feature/16-*` | Med | None | pending |
+| T16 | Status bar verification: confirm acceptance criteria met | #21 | `feature/21-*` | Low | T9 | pending |
+
+---
+
+## Exit Criteria
+
+- [ ] All Must-Have acceptance scenarios pass manually in `just dev-mock` mode
+- [ ] Grid loads first page in <2 seconds on local PostgreSQL (`just dev`)
+- [ ] Virtual scrolling confirmed active (DOM element count << total rows)
+- [ ] Sort, filter, and pagination work end-to-end against live PostgreSQL
+- [ ] No SQL injection vectors via sort_column, filter params (server-side validation already in place — verify not bypassed)
+- [ ] No regressions on existing sidebar, toolbar, status bar functionality
+- [ ] Single binary build (`just build`) succeeds with embedded assets
+- [ ] `cargo test` and `npm run check` pass
+- [ ] `npm run test` passes (existing + any new unit tests)
+
+---
+
+## References
+
+- Epic issue: [#3](https://github.com/Kiriketsuki/seeKi/issues/3)
+- Epic PR: [#29](https://github.com/Kiriketsuki/seeKi/pull/29)
+- Feature issues: [#16](https://github.com/Kiriketsuki/seeKi/issues/16), [#17](https://github.com/Kiriketsuki/seeKi/issues/17), [#18](https://github.com/Kiriketsuki/seeKi/issues/18), [#19](https://github.com/Kiriketsuki/seeKi/issues/19), [#20](https://github.com/Kiriketsuki/seeKi/issues/20), [#21](https://github.com/Kiriketsuki/seeKi/issues/21)
+- Backend API: `src/api/mod.rs` — sort/filter/pagination params already implemented
+- MVP spec: `seeki-mvp-spec.md`
+- Brainstorming session: `.brainstorm/` directory in repo root
+
+---
+
+*Authored by: Clault KiperS 4.6*

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -206,7 +206,7 @@
 
   function exportCsv() {
     if (!selectedTable) return;
-    const params = buildRowsParams(currentPage);
+    const params = buildRowsParams(1);
     const searchParams = new URLSearchParams();
     if (params.sort_column) searchParams.set('sort_column', params.sort_column);
     if (params.sort_direction) searchParams.set('sort_direction', params.sort_direction);

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -206,7 +206,17 @@
 
   function exportCsv() {
     if (!selectedTable) return;
-    window.open(`/api/export/${encodeURIComponent(selectedTable)}/csv`, '_blank');
+    const params = buildRowsParams(currentPage);
+    const searchParams = new URLSearchParams();
+    if (params.sort_column) searchParams.set('sort_column', params.sort_column);
+    if (params.sort_direction) searchParams.set('sort_direction', params.sort_direction);
+    if (params.filters) {
+      for (const [col, val] of Object.entries(params.filters)) {
+        searchParams.set(`filter.${col}`, val);
+      }
+    }
+    const qs = searchParams.toString();
+    window.open(`/api/export/${encodeURIComponent(selectedTable)}/csv${qs ? `?${qs}` : ''}`, '_blank');
   }
 </script>
 

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -3,10 +3,18 @@
   import Sidebar from './components/Sidebar.svelte';
   import TableList from './components/TableList.svelte';
   import Toolbar from './components/Toolbar.svelte';
+  import ToolStrip from './components/ToolStrip.svelte';
   import DataGrid from './components/DataGrid.svelte';
   import StatusBar from './components/StatusBar.svelte';
   import { fetchTables, fetchColumns, fetchRows, fetchDisplayConfig, fetchStatus } from './lib/api';
-  import type { TableInfo, ColumnInfo, QueryResult, DisplayConfig } from './lib/types';
+  import type {
+    TableInfo,
+    ColumnInfo,
+    QueryResult,
+    DisplayConfig,
+    SortState,
+    FilterState,
+  } from './lib/types';
   import { SIDEBAR_COLLAPSED_KEY } from './lib/constants';
 
   let tables: TableInfo[] = $state([]);
@@ -23,7 +31,13 @@
   let error: string | null = $state(null);
   let tableError: string | null = $state(null);
   let currentPage: number = $state(1);
+  let sortState: SortState = $state({ column: null, direction: null });
+  let filtersVisible: boolean = $state(false);
+  let filters: FilterState = $state({});
   let selectRequestId = 0;
+  let activeFilterCount = $derived(
+    Object.values(filters).filter((value) => value.trim().length > 0).length
+  );
 
   onMount(async () => {
     try {
@@ -54,6 +68,9 @@
     tableError = null;
     tableLoading = true;
     currentPage = 1;
+    sortState = { column: null, direction: null };
+    filtersVisible = false;
+    filters = {};
     try {
       const [cols, result] = await Promise.all([
         fetchColumns(tableName),
@@ -68,6 +85,10 @@
     } finally {
       if (myRequest === selectRequestId) tableLoading = false;
     }
+  }
+
+  function toggleFilters() {
+    filtersVisible = !filtersVisible;
   }
 
   async function goToPage(page: number) {
@@ -150,13 +171,21 @@
           <button class="dismiss-btn" onclick={() => tableError = null}>Dismiss</button>
         </div>
       {/if}
-      <div class="grid-area" class:loading-overlay={tableLoading}>
-        <DataGrid {columns} rows={queryResult?.rows ?? []} />
-        {#if tableLoading}
-          <div class="grid-loading">
-            <div class="loading-spinner"></div>
-          </div>
-        {/if}
+      <div class="grid-area">
+        <ToolStrip
+          {sortState}
+          filtersVisible={filtersVisible}
+          activeFilterCount={activeFilterCount}
+          onToggleFilters={toggleFilters}
+        />
+        <div class="grid-shell" class:loading-overlay={tableLoading}>
+          <DataGrid {columns} rows={queryResult?.rows ?? []} />
+          {#if tableLoading}
+            <div class="grid-loading">
+              <div class="loading-spinner"></div>
+            </div>
+          {/if}
+        </div>
       </div>
       <StatusBar
         total={queryResult?.total_rows ?? 0}
@@ -183,11 +212,21 @@
     display: flex;
     flex-direction: column;
     min-width: 0;
+    min-height: 0;
   }
   .grid-area {
     flex: 1;
+    min-height: 0;
+    display: flex;
+    gap: var(--sk-space-md);
     padding: var(--sk-space-lg) var(--sk-space-2xl);
-    overflow: auto;
+    overflow: hidden;
+    align-items: stretch;
+  }
+  .grid-shell {
+    flex: 1;
+    min-width: 0;
+    min-height: 0;
     position: relative;
   }
   .loading-overlay {
@@ -200,6 +239,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    background: rgba(245, 240, 235, 0.28);
   }
   .loading-state {
     flex: 1;

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -7,6 +7,7 @@
   import DataGrid from './components/DataGrid.svelte';
   import StatusBar from './components/StatusBar.svelte';
   import { fetchTables, fetchColumns, fetchRows, fetchDisplayConfig, fetchStatus } from './lib/api';
+  import type { FetchRowsParams } from './lib/api';
   import type {
     TableInfo,
     ColumnInfo,
@@ -14,6 +15,7 @@
     DisplayConfig,
     SortState,
     FilterState,
+    SortDirection,
   } from './lib/types';
   import { SIDEBAR_COLLAPSED_KEY } from './lib/constants';
 
@@ -38,6 +40,15 @@
   let activeFilterCount = $derived(
     Object.values(filters).filter((value) => value.trim().length > 0).length
   );
+  let sortLabel = $derived.by(() => {
+    if (!sortState.column || !sortState.direction) {
+      return 'No active sort';
+    }
+
+    const currentColumn = columns.find((column) => column.name === sortState.column);
+    const displayName = currentColumn?.display_name ?? sortState.column;
+    return `${displayName} ${sortState.direction}`;
+  });
 
   onMount(async () => {
     try {
@@ -64,17 +75,19 @@
 
   async function selectTable(tableName: string) {
     const myRequest = ++selectRequestId;
+    const resetSortState: SortState = { column: null, direction: null };
+    const resetFilters: FilterState = {};
     selectedTable = tableName;
     tableError = null;
     tableLoading = true;
     currentPage = 1;
-    sortState = { column: null, direction: null };
+    sortState = resetSortState;
     filtersVisible = false;
-    filters = {};
+    filters = resetFilters;
     try {
       const [cols, result] = await Promise.all([
         fetchColumns(tableName),
-        fetchRows(tableName)
+        fetchRows(tableName, buildRowsParams(1, resetSortState, resetFilters))
       ]);
       if (myRequest !== selectRequestId) return;
       columns = cols;
@@ -91,22 +104,62 @@
     filtersVisible = !filtersVisible;
   }
 
-  async function goToPage(page: number) {
+  function buildRowsParams(
+    page: number,
+    nextSortState: SortState = sortState,
+    nextFilters: FilterState = filters,
+  ): FetchRowsParams {
+    const params: FetchRowsParams = { page };
+    if (nextSortState.column && nextSortState.direction) {
+      params.sort_column = nextSortState.column;
+      params.sort_direction = nextSortState.direction;
+    }
+
+    const activeFilters = Object.fromEntries(
+      Object.entries(nextFilters).filter(([, value]) => value.trim().length > 0)
+    );
+    if (Object.keys(activeFilters).length > 0) {
+      params.filters = activeFilters;
+    }
+
+    return params;
+  }
+
+  async function loadRows(
+    page: number,
+    nextSortState: SortState = sortState,
+    nextFilters: FilterState = filters,
+  ) {
     if (!selectedTable) return;
     const myRequest = ++selectRequestId;
     tableError = null;
     tableLoading = true;
     try {
-      const result = await fetchRows(selectedTable, { page });
+      const result = await fetchRows(
+        selectedTable,
+        buildRowsParams(page, nextSortState, nextFilters)
+      );
       if (myRequest !== selectRequestId) return;
       queryResult = result;
       currentPage = page;
     } catch (e) {
       if (myRequest !== selectRequestId) return;
-      tableError = e instanceof Error ? e.message : 'Failed to load page';
+      tableError = e instanceof Error ? e.message : 'Failed to load rows';
     } finally {
       if (myRequest === selectRequestId) tableLoading = false;
     }
+  }
+
+  async function goToPage(page: number) {
+    await loadRows(page);
+  }
+
+  function handleSortChange(column: string, direction: SortDirection | null) {
+    const nextSortState: SortState = direction
+      ? { column, direction }
+      : { column: null, direction: null };
+    sortState = nextSortState;
+    void loadRows(1, nextSortState);
   }
 
   function exportCsv() {
@@ -174,12 +227,18 @@
       <div class="grid-area">
         <ToolStrip
           {sortState}
+          sortDescription={sortLabel}
           filtersVisible={filtersVisible}
           activeFilterCount={activeFilterCount}
           onToggleFilters={toggleFilters}
         />
         <div class="grid-shell" class:loading-overlay={tableLoading}>
-          <DataGrid {columns} rows={queryResult?.rows ?? []} />
+          <DataGrid
+            {columns}
+            rows={queryResult?.rows ?? []}
+            {sortState}
+            onSortChange={handleSortChange}
+          />
           {#if tableLoading}
             <div class="grid-loading">
               <div class="loading-spinner"></div>

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -36,6 +36,7 @@
   let sortState: SortState = $state({ column: null, direction: null });
   let filtersVisible: boolean = $state(false);
   let filters: FilterState = $state({});
+  let filterDebounceId: ReturnType<typeof setTimeout> | null = null;
   let selectRequestId = 0;
   let activeFilterCount = $derived(
     Object.values(filters).filter((value) => value.trim().length > 0).length
@@ -73,6 +74,23 @@
     }
   });
 
+  onMount(() => {
+    function handleKeydown(event: KeyboardEvent) {
+      if (event.defaultPrevented || event.altKey) return;
+      if (!event.ctrlKey && !event.metaKey) return;
+      if (event.key.toLowerCase() !== 'f') return;
+
+      event.preventDefault();
+      toggleFilters();
+    }
+
+    window.addEventListener('keydown', handleKeydown);
+    return () => {
+      window.removeEventListener('keydown', handleKeydown);
+      clearFilterDebounce();
+    };
+  });
+
   async function selectTable(tableName: string) {
     const myRequest = ++selectRequestId;
     const resetSortState: SortState = { column: null, direction: null };
@@ -84,6 +102,7 @@
     sortState = resetSortState;
     filtersVisible = false;
     filters = resetFilters;
+    clearFilterDebounce();
     try {
       const [cols, result] = await Promise.all([
         fetchColumns(tableName),
@@ -102,6 +121,13 @@
 
   function toggleFilters() {
     filtersVisible = !filtersVisible;
+  }
+
+  function clearFilterDebounce() {
+    if (filterDebounceId != null) {
+      clearTimeout(filterDebounceId);
+      filterDebounceId = null;
+    }
   }
 
   function buildRowsParams(
@@ -151,15 +177,31 @@
   }
 
   async function goToPage(page: number) {
+    clearFilterDebounce();
     await loadRows(page);
   }
 
   function handleSortChange(column: string, direction: SortDirection | null) {
+    clearFilterDebounce();
     const nextSortState: SortState = direction
       ? { column, direction }
       : { column: null, direction: null };
     sortState = nextSortState;
     void loadRows(1, nextSortState);
+  }
+
+  function handleFilterChange(column: string, value: string) {
+    const nextFilters: FilterState = {
+      ...filters,
+      [column]: value,
+    };
+    filters = nextFilters;
+
+    clearFilterDebounce();
+    filterDebounceId = setTimeout(() => {
+      void loadRows(1, sortState, nextFilters);
+      filterDebounceId = null;
+    }, 300);
   }
 
   function exportCsv() {
@@ -237,7 +279,10 @@
             {columns}
             rows={queryResult?.rows ?? []}
             {sortState}
+            {filters}
+            {filtersVisible}
             onSortChange={handleSortChange}
+            onFilterChange={handleFilterChange}
           />
           {#if tableLoading}
             <div class="grid-loading">

--- a/frontend/src/components/DataGrid.svelte
+++ b/frontend/src/components/DataGrid.svelte
@@ -63,6 +63,12 @@
     );
     const isSorted = props.order != null;
 
+    const ariaSortValue = props.order === 'asc'
+      ? 'ascending'
+      : props.order === 'desc'
+        ? 'descending'
+        : undefined;
+
     return h(
       'div',
       {
@@ -71,6 +77,7 @@
           'has-filters': showFilters,
           'is-sorted': isSorted,
         },
+        ...(ariaSortValue ? { 'aria-sort': ariaSortValue } : {}),
       },
       [
         h(

--- a/frontend/src/components/DataGrid.svelte
+++ b/frontend/src/components/DataGrid.svelte
@@ -7,7 +7,12 @@
     type HyperFunc,
   } from '@revolist/svelte-datagrid';
   import type { VNode } from '@revolist/revogrid';
-  import type { ColumnInfo, SortDirection, SortState } from '../lib/types';
+  import type {
+    ColumnInfo,
+    FilterState,
+    SortDirection,
+    SortState,
+  } from '../lib/types';
   import {
     buildSortableColumn,
     formatCellValue,
@@ -19,12 +24,18 @@
     columns = [],
     rows = [],
     sortState,
+    filters = {},
+    filtersVisible = false,
     onSortChange,
+    onFilterChange,
   }: {
     columns: ColumnInfo[];
     rows: Record<string, unknown>[];
     sortState: SortState;
+    filters?: FilterState;
+    filtersVisible?: boolean;
     onSortChange?: (column: string, direction: SortDirection | null) => void;
+    onFilterChange?: (column: string, value: string) => void;
   } = $props();
 
   type SortEventDetail = {
@@ -44,35 +55,72 @@
   ): VNode {
     const info = columnsByName.get(String(props.prop));
     const label = info ? getColumnDisplayName(info) : String(props.name ?? props.prop);
-    const isSorted = sortState.column === props.prop && sortState.direction != null;
+    const showFilters = Boolean(
+      (props as ColumnTemplateProp & { showFilters?: boolean }).showFilters
+    );
+    const filterValue = String(
+      (props as ColumnTemplateProp & { filterValue?: string }).filterValue ?? ''
+    );
+    const isSorted = props.order != null;
 
     return h(
       'div',
       {
         class: {
           'sk-grid-header': true,
+          'has-filters': showFilters,
           'is-sorted': isSorted,
         },
       },
       [
-        h('span', { class: { 'sk-grid-header__label': true } }, label),
         h(
-          'span',
+          'div',
           {
             class: {
-              'sk-grid-header__sort': true,
-              'is-active': isSorted,
+              'sk-grid-header__top': true,
             },
-            'aria-hidden': 'true',
           },
-          sortState.column === props.prop
-            ? sortState.direction === 'asc'
-              ? '▲'
-              : sortState.direction === 'desc'
-                ? '▼'
-                : ''
-            : ''
+          [
+            h('span', { class: { 'sk-grid-header__label': true } }, label),
+            h(
+              'span',
+              {
+                class: {
+                  'sk-grid-header__sort': true,
+                  'is-active': isSorted,
+              },
+              'aria-hidden': 'true',
+            },
+              props.order === 'asc'
+                ? '▲'
+                : props.order === 'desc'
+                  ? '▼'
+                  : ''
+            ),
+          ]
         ),
+        showFilters
+          ? h('div', { class: { 'sk-grid-filter': true } }, [
+              h('input', {
+                class: {
+                  'sk-grid-filter__input': true,
+                },
+                type: 'text',
+                value: filterValue,
+                placeholder: 'Filter',
+                'aria-label': `Filter ${label}`,
+                onInput: (event: Event) =>
+                  onFilterChange?.(
+                    String(props.prop),
+                    (event.target as HTMLInputElement).value
+                  ),
+                onClick: (event: Event) => event.stopPropagation(),
+                onMouseDown: (event: Event) => event.stopPropagation(),
+                onDblClick: (event: Event) => event.stopPropagation(),
+                onKeyDown: (event: Event) => event.stopPropagation(),
+              }),
+            ])
+          : null,
       ]
     );
   }
@@ -147,6 +195,10 @@
   let gridColumns: ColumnRegular[] = $derived(
     columns.map((column) =>
       buildSortableColumn(column, {
+        order:
+          sortState.column === column.name ? sortState.direction ?? undefined : undefined,
+        filterValue: filters[column.name] ?? '',
+        showFilters: filtersVisible,
         columnTemplate: renderHeader,
         cellTemplate: renderCell,
       })
@@ -154,7 +206,7 @@
   );
 </script>
 
-<div class="grid-card">
+<div class="grid-card" class:filters-visible={filtersVisible}>
   <RevoGrid
     columns={gridColumns}
     source={rows}
@@ -193,11 +245,21 @@
 
   .grid-card :global(.sk-grid-header) {
     display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    justify-content: center;
+    gap: 6px;
+    width: 100%;
+    color: inherit;
+  }
+
+  .grid-card :global(.sk-grid-header__top) {
+    display: flex;
     align-items: center;
     justify-content: space-between;
     gap: var(--sk-space-sm);
     width: 100%;
-    color: inherit;
+    min-height: 18px;
   }
 
   .grid-card :global(.sk-grid-header__label) {
@@ -215,6 +277,32 @@
 
   .grid-card :global(.sk-grid-header__sort.is-active) {
     color: var(--sk-accent);
+  }
+
+  .grid-card :global(.sk-grid-filter) {
+    width: 100%;
+  }
+
+  .grid-card :global(.sk-grid-filter__input) {
+    width: 100%;
+    border: 1px solid var(--sk-border-light);
+    border-radius: var(--sk-radius-sm);
+    background: rgba(255, 255, 255, 0.8);
+    color: var(--sk-text);
+    font-family: var(--sk-font-ui);
+    font-size: var(--sk-font-size-body);
+    line-height: 1.3;
+    padding: 4px 8px;
+    outline: none;
+  }
+
+  .grid-card :global(.sk-grid-filter__input:focus) {
+    border-color: rgba(0, 169, 165, 0.45);
+    box-shadow: 0 0 0 2px rgba(0, 169, 165, 0.12);
+  }
+
+  .grid-card :global(.sk-grid-filter__input::placeholder) {
+    color: var(--sk-muted);
   }
 
   .grid-card :global(.sk-grid-cell) {
@@ -269,5 +357,18 @@
   .grid-card :global(.sk-grid-badge.is-false) {
     background: rgba(220, 38, 38, 0.12);
     color: var(--sk-boolean-false);
+  }
+
+  .filters-visible :global(revo-grid[theme='compact'] revogr-header) {
+    line-height: normal;
+  }
+
+  .filters-visible :global(revo-grid[theme='compact'] revogr-header .header-rgRow) {
+    height: 72px;
+  }
+
+  .filters-visible :global(revo-grid[theme='compact'] revogr-header .rgHeaderCell) {
+    padding-top: 10px;
+    padding-bottom: 10px;
   }
 </style>

--- a/frontend/src/components/DataGrid.svelte
+++ b/frontend/src/components/DataGrid.svelte
@@ -1,45 +1,169 @@
 <script lang="ts">
-  import { RevoGrid } from '@revolist/svelte-datagrid';
-  import type { ColumnInfo } from '../lib/types';
+  import {
+    RevoGrid,
+    type CellTemplateProp,
+    type ColumnRegular,
+    type ColumnTemplateProp,
+    type HyperFunc,
+  } from '@revolist/svelte-datagrid';
+  import type { VNode } from '@revolist/revogrid';
+  import type { ColumnInfo, SortDirection, SortState } from '../lib/types';
+  import {
+    buildSortableColumn,
+    formatCellValue,
+    getColumnDisplayName,
+    sortStateToConfig,
+  } from '../lib/data-grid';
 
   let {
     columns = [],
     rows = [],
+    sortState,
+    onSortChange,
   }: {
     columns: ColumnInfo[];
     rows: Record<string, unknown>[];
+    sortState: SortState;
+    onSortChange?: (column: string, direction: SortDirection | null) => void;
   } = $props();
 
-  function columnWidth(col: ColumnInfo): number {
-    switch (col.data_type) {
-      case 'boolean': return 80;
-      case 'smallint':
-      case 'integer': return 100;
-      case 'bigint':
-      case 'real':
-      case 'double precision':
-      case 'numeric': return 120;
-      case 'date': return 110;
-      case 'time without time zone':
-      case 'time with time zone': return 100;
-      case 'timestamp without time zone':
-      case 'timestamp with time zone': return 180;
-      case 'uuid': return 280;
-      case 'json':
-      case 'jsonb': return 250;
-      default: return 150;
-    }
+  type SortEventDetail = {
+    column: ColumnRegular;
+    order?: SortDirection;
+    additive: boolean;
+  };
+
+  let columnsByName = $derived(
+    new Map(columns.map((column) => [column.name, column]))
+  );
+  let sorting = $derived(sortStateToConfig(sortState));
+
+  function renderHeader(
+    h: HyperFunc<VNode>,
+    props: ColumnTemplateProp,
+  ): VNode {
+    const info = columnsByName.get(String(props.prop));
+    const label = info ? getColumnDisplayName(info) : String(props.name ?? props.prop);
+    const isSorted = sortState.column === props.prop && sortState.direction != null;
+
+    return h(
+      'div',
+      {
+        class: {
+          'sk-grid-header': true,
+          'is-sorted': isSorted,
+        },
+      },
+      [
+        h('span', { class: { 'sk-grid-header__label': true } }, label),
+        h(
+          'span',
+          {
+            class: {
+              'sk-grid-header__sort': true,
+              'is-active': isSorted,
+            },
+            'aria-hidden': 'true',
+          },
+          sortState.column === props.prop
+            ? sortState.direction === 'asc'
+              ? '▲'
+              : sortState.direction === 'desc'
+                ? '▼'
+                : ''
+            : ''
+        ),
+      ]
+    );
   }
 
-  let gridColumns = $derived(columns.map(col => ({
-    prop: col.name,
-    name: col.display_name || col.name,
-    size: columnWidth(col),
-  })));
+  function renderCell(
+    h: HyperFunc<VNode>,
+    props: CellTemplateProp,
+  ): VNode {
+    const info = columnsByName.get(String(props.prop));
+    if (!info) {
+      return h(
+        'div',
+        { class: { 'sk-grid-cell': true } },
+        String(props.value ?? '')
+      );
+    }
+
+    const formatted = formatCellValue(info, props.value);
+
+    if (formatted.kind === 'null') {
+      return h(
+        'div',
+        {
+          class: {
+            'sk-grid-cell': true,
+            'sk-grid-cell--null': true,
+          },
+        },
+        formatted.display
+      );
+    }
+
+    if (formatted.kind === 'boolean') {
+      return h(
+        'div',
+        { class: { 'sk-grid-cell': true, 'sk-grid-cell--boolean': true } },
+        [
+          h(
+            'span',
+            {
+              class: {
+                'sk-grid-badge': true,
+                'is-true': formatted.booleanValue === true,
+                'is-false': formatted.booleanValue === false,
+              },
+            },
+            formatted.display
+          ),
+        ]
+      );
+    }
+
+    return h(
+      'div',
+      {
+        class: {
+          'sk-grid-cell': true,
+          'sk-grid-cell--number': formatted.kind === 'number',
+          'sk-grid-cell--timestamp': formatted.kind === 'timestamp',
+        },
+        title: formatted.tooltip,
+      },
+      formatted.display
+    );
+  }
+
+  function handleBeforeSorting(event: CustomEvent<SortEventDetail>) {
+    event.preventDefault();
+    onSortChange?.(String(event.detail.column.prop), event.detail.order ?? null);
+  }
+
+  let gridColumns: ColumnRegular[] = $derived(
+    columns.map((column) =>
+      buildSortableColumn(column, {
+        columnTemplate: renderHeader,
+        cellTemplate: renderCell,
+      })
+    )
+  );
 </script>
 
 <div class="grid-card">
-  <RevoGrid columns={gridColumns} source={rows} theme="compact" />
+  <RevoGrid
+    columns={gridColumns}
+    source={rows}
+    sorting={sorting}
+    readonly={true}
+    resize={true}
+    theme="compact"
+    on:beforesorting={handleBeforeSorting}
+  />
 </div>
 
 <style>
@@ -52,5 +176,98 @@
     box-shadow: var(--sk-shadow-card);
     overflow: hidden;
     height: 100%;
+  }
+
+  .grid-card :global(revo-grid) {
+    --revo-grid-background: transparent;
+    --revo-grid-header-bg: rgba(255, 255, 255, 0.6);
+    --revo-grid-header-color: var(--sk-text);
+    --revo-grid-header-border: rgba(47, 72, 88, 0.08);
+    --revo-grid-cell-border: rgba(47, 72, 88, 0.06);
+    --revo-grid-row-hover: rgba(0, 169, 165, 0.08);
+    --revo-grid-text: var(--sk-text);
+    --revo-grid-focused-bg: rgba(0, 169, 165, 0.08);
+    font-family: var(--sk-font-ui);
+    font-size: var(--sk-font-size-body);
+  }
+
+  .grid-card :global(.sk-grid-header) {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--sk-space-sm);
+    width: 100%;
+    color: inherit;
+  }
+
+  .grid-card :global(.sk-grid-header__label) {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .grid-card :global(.sk-grid-header__sort) {
+    min-width: 1ch;
+    color: var(--sk-muted);
+    font-size: 10px;
+  }
+
+  .grid-card :global(.sk-grid-header__sort.is-active) {
+    color: var(--sk-accent);
+  }
+
+  .grid-card :global(.sk-grid-cell) {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+
+  .grid-card :global(.sk-grid-cell--number) {
+    justify-content: flex-end;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .grid-card :global(.sk-grid-cell--timestamp) {
+    color: var(--sk-secondary-strong);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .grid-card :global(.sk-grid-cell--boolean) {
+    justify-content: center;
+  }
+
+  .grid-card :global(.sk-grid-cell--null) {
+    justify-content: center;
+    border-radius: var(--sk-radius-sm);
+    background-image: var(--sk-null-hatch);
+    color: var(--sk-muted);
+    font-style: italic;
+  }
+
+  .grid-card :global(.sk-grid-badge) {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 42px;
+    padding: 2px 8px;
+    border-radius: 999px;
+    font-size: var(--sk-font-size-sm);
+    font-weight: 600;
+    line-height: 1.4;
+  }
+
+  .grid-card :global(.sk-grid-badge.is-true) {
+    background: rgba(22, 163, 74, 0.12);
+    color: var(--sk-boolean-true);
+  }
+
+  .grid-card :global(.sk-grid-badge.is-false) {
+    background: rgba(220, 38, 38, 0.12);
+    color: var(--sk-boolean-false);
   }
 </style>

--- a/frontend/src/components/StatusBar.svelte
+++ b/frontend/src/components/StatusBar.svelte
@@ -30,6 +30,7 @@
 
   <div class="pagination">
     <button
+      type="button"
       class="page-btn"
       disabled={!canPrev}
       aria-label="Previous page"
@@ -39,6 +40,7 @@
     </button>
     <span class="page-info">{page} of {totalPages}</span>
     <button
+      type="button"
       class="page-btn"
       disabled={!canNext}
       aria-label="Next page"

--- a/frontend/src/components/StatusBar.svelte
+++ b/frontend/src/components/StatusBar.svelte
@@ -25,7 +25,7 @@
 
 <div class="statusbar">
   <span class="showing">
-    Showing {start.toLocaleString()} – {end.toLocaleString()} of {total.toLocaleString()}
+    Showing {start.toLocaleString()} - {end.toLocaleString()} of {total.toLocaleString()}
   </span>
 
   <div class="pagination">

--- a/frontend/src/components/TableList.svelte
+++ b/frontend/src/components/TableList.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { Search } from 'lucide-svelte';
   import type { TableInfo } from '../lib/types';
 
   let {
@@ -10,21 +11,49 @@
     selectedTable: string;
     onSelect: (tableName: string) => void;
   } = $props();
+
+  let search = $state('');
+  let filteredTables = $derived.by(() => {
+    const query = search.trim().toLowerCase();
+    if (!query) {
+      return tables;
+    }
+
+    return tables.filter((table) =>
+      table.display_name.toLowerCase().includes(query)
+    );
+  });
 </script>
 
 <nav class="table-list">
-  {#each tables as table}
-    <button
-      class="table-item"
-      class:active={selectedTable === table.name}
-      onclick={() => onSelect(table.name)}
-    >
-      <span class="table-item-name">{table.display_name}</span>
-      {#if table.row_count_estimate != null}
-        <span class="table-item-count">{table.row_count_estimate.toLocaleString()}</span>
-      {/if}
-    </button>
-  {/each}
+  <div class="table-search">
+    <Search size={14} />
+    <input
+      bind:value={search}
+      class="table-search-input"
+      type="search"
+      placeholder="Search tables"
+      aria-label="Search tables"
+      spellcheck="false"
+    />
+  </div>
+
+  {#if filteredTables.length > 0}
+    {#each filteredTables as table}
+      <button
+        class="table-item"
+        class:active={selectedTable === table.name}
+        onclick={() => onSelect(table.name)}
+      >
+        <span class="table-item-name">{table.display_name}</span>
+        {#if table.row_count_estimate != null}
+          <span class="table-item-count">{table.row_count_estimate.toLocaleString()}</span>
+        {/if}
+      </button>
+    {/each}
+  {:else}
+    <div class="empty-state">No tables match “{search.trim()}”.</div>
+  {/if}
 </nav>
 
 <style>
@@ -34,6 +63,37 @@
     gap: 2px;
     padding: var(--sk-space-xs) 0;
   }
+
+  .table-search {
+    display: flex;
+    align-items: center;
+    gap: var(--sk-space-sm);
+    margin-bottom: var(--sk-space-sm);
+    padding: 0 var(--sk-space-md);
+    color: var(--sk-muted);
+  }
+
+  .table-search-input {
+    width: 100%;
+    border: 1px solid var(--sk-border-light);
+    border-radius: var(--sk-radius-md);
+    background: rgba(255, 255, 255, 0.72);
+    color: var(--sk-text);
+    font-family: var(--sk-font-ui);
+    font-size: var(--sk-font-size-body);
+    padding: 6px 10px;
+    outline: none;
+  }
+
+  .table-search-input:focus {
+    border-color: rgba(0, 169, 165, 0.4);
+    box-shadow: 0 0 0 2px rgba(0, 169, 165, 0.12);
+  }
+
+  .table-search-input::placeholder {
+    color: var(--sk-muted);
+  }
+
   .table-item {
     display: flex;
     align-items: center;
@@ -70,5 +130,11 @@
   }
   .table-item.active .table-item-count {
     color: rgba(255, 255, 255, 0.7);
+  }
+
+  .empty-state {
+    padding: var(--sk-space-sm) var(--sk-space-md);
+    color: var(--sk-muted);
+    font-size: var(--sk-font-size-body);
   }
 </style>

--- a/frontend/src/components/TableList.svelte
+++ b/frontend/src/components/TableList.svelte
@@ -41,6 +41,7 @@
   {#if filteredTables.length > 0}
     {#each filteredTables as table}
       <button
+        type="button"
         class="table-item"
         class:active={selectedTable === table.name}
         onclick={() => onSelect(table.name)}

--- a/frontend/src/components/ToolStrip.svelte
+++ b/frontend/src/components/ToolStrip.svelte
@@ -81,8 +81,8 @@
     <button
       class="tool-button tool-button-disabled"
       disabled
-      aria-label="Export tools coming later"
-      title="Export tools coming later"
+      aria-label="More export options coming soon"
+      title="More export options coming soon"
       type="button"
     >
       <Download size={16} />

--- a/frontend/src/components/ToolStrip.svelte
+++ b/frontend/src/components/ToolStrip.svelte
@@ -54,7 +54,7 @@
       </span>
     </button>
 
-    <div class="tool-indicator" aria-label={computedSortLabel} title={computedSortLabel}>
+    <div class="tool-indicator" role="status" aria-label={computedSortLabel} title={computedSortLabel}>
       {#if sortState.direction === 'asc'}
         <ChevronUp size={16} />
       {:else if sortState.direction === 'desc'}

--- a/frontend/src/components/ToolStrip.svelte
+++ b/frontend/src/components/ToolStrip.svelte
@@ -54,7 +54,7 @@
       </span>
     </button>
 
-    <div class="tool-indicator" role="status" aria-label={computedSortLabel} title={computedSortLabel}>
+    <div class="tool-indicator" aria-label={computedSortLabel} title={computedSortLabel}>
       {#if sortState.direction === 'asc'}
         <ChevronUp size={16} />
       {:else if sortState.direction === 'desc'}

--- a/frontend/src/components/ToolStrip.svelte
+++ b/frontend/src/components/ToolStrip.svelte
@@ -11,17 +11,23 @@
 
   let {
     sortState,
+    sortDescription,
     filtersVisible = false,
     activeFilterCount = 0,
     onToggleFilters,
   }: {
     sortState: SortState;
+    sortDescription?: string;
     filtersVisible?: boolean;
     activeFilterCount?: number;
     onToggleFilters?: () => void;
   } = $props();
 
-  let sortLabel = $derived.by(() => {
+  let computedSortLabel = $derived.by(() => {
+    if (sortDescription) {
+      return sortDescription;
+    }
+
     if (!sortState.column || !sortState.direction) {
       return 'No active sort';
     }
@@ -48,7 +54,7 @@
       </span>
     </button>
 
-    <div class="tool-indicator" aria-label={sortLabel} title={sortLabel}>
+    <div class="tool-indicator" aria-label={computedSortLabel} title={computedSortLabel}>
       {#if sortState.direction === 'asc'}
         <ChevronUp size={16} />
       {:else if sortState.direction === 'desc'}

--- a/frontend/src/components/ToolStrip.svelte
+++ b/frontend/src/components/ToolStrip.svelte
@@ -1,0 +1,186 @@
+<script lang="ts">
+  import {
+    ArrowUpDown,
+    ChevronDown,
+    ChevronUp,
+    Download,
+    Filter,
+    LayoutGrid,
+  } from 'lucide-svelte';
+  import type { SortState } from '../lib/types';
+
+  let {
+    sortState,
+    filtersVisible = false,
+    activeFilterCount = 0,
+    onToggleFilters,
+  }: {
+    sortState: SortState;
+    filtersVisible?: boolean;
+    activeFilterCount?: number;
+    onToggleFilters?: () => void;
+  } = $props();
+
+  let sortLabel = $derived.by(() => {
+    if (!sortState.column || !sortState.direction) {
+      return 'No active sort';
+    }
+
+    return `${sortState.column} ${sortState.direction}`;
+  });
+</script>
+
+<aside class="tool-strip" aria-label="Data tools">
+  <div class="tool-section">
+    <button
+      class="tool-button"
+      class:active={filtersVisible}
+      aria-label="Toggle filters"
+      title="Toggle filters"
+      onclick={() => onToggleFilters?.()}
+      type="button"
+    >
+      <span class="icon-stack">
+        <Filter size={16} />
+        {#if activeFilterCount > 0}
+          <span class="badge">{activeFilterCount}</span>
+        {/if}
+      </span>
+    </button>
+
+    <div class="tool-indicator" aria-label={sortLabel} title={sortLabel}>
+      {#if sortState.direction === 'asc'}
+        <ChevronUp size={16} />
+      {:else if sortState.direction === 'desc'}
+        <ChevronDown size={16} />
+      {:else}
+        <ArrowUpDown size={16} />
+      {/if}
+    </div>
+  </div>
+
+  <div class="separator"></div>
+
+  <div class="tool-section tool-section-bottom">
+    <button
+      class="tool-button tool-button-disabled"
+      disabled
+      aria-label="Column visibility coming later"
+      title="Column visibility coming later"
+      type="button"
+    >
+      <LayoutGrid size={16} />
+    </button>
+
+    <button
+      class="tool-button tool-button-disabled"
+      disabled
+      aria-label="Export tools coming later"
+      title="Export tools coming later"
+      type="button"
+    >
+      <Download size={16} />
+    </button>
+  </div>
+</aside>
+
+<style>
+  .tool-strip {
+    width: var(--sk-toolstrip-width);
+    min-width: var(--sk-toolstrip-width);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--sk-space-md);
+    padding: var(--sk-space-md) 0;
+    background: var(--sk-glass-sidebar);
+    backdrop-filter: var(--sk-glass-sidebar-blur);
+    -webkit-backdrop-filter: var(--sk-glass-sidebar-blur);
+    border: 1px solid var(--sk-border-light);
+    border-radius: var(--sk-radius-lg);
+    box-shadow: var(--sk-shadow-card);
+  }
+
+  .tool-section {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--sk-space-sm);
+    width: 100%;
+  }
+
+  .tool-section-bottom {
+    margin-top: auto;
+  }
+
+  .separator {
+    width: 20px;
+    height: 1px;
+    background: var(--sk-border);
+  }
+
+  .tool-button,
+  .tool-indicator {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border: 1px solid var(--sk-border-light);
+    border-radius: var(--sk-radius-md);
+    background: var(--sk-glass-button);
+    backdrop-filter: var(--sk-glass-button-blur);
+    -webkit-backdrop-filter: var(--sk-glass-button-blur);
+    color: var(--sk-muted);
+  }
+
+  .tool-button {
+    cursor: pointer;
+  }
+
+  .tool-button:hover:not(:disabled),
+  .tool-button.active {
+    color: var(--sk-text);
+    border-color: rgba(0, 169, 165, 0.3);
+    box-shadow: var(--sk-shadow-accent);
+  }
+
+  .tool-button.active {
+    background: rgba(0, 169, 165, 0.14);
+  }
+
+  .tool-button-disabled {
+    cursor: not-allowed;
+    opacity: 0.55;
+  }
+
+  .tool-indicator {
+    pointer-events: none;
+  }
+
+  .icon-stack {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .badge {
+    position: absolute;
+    top: -7px;
+    right: -10px;
+    min-width: 16px;
+    height: 16px;
+    padding: 0 4px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 999px;
+    background: var(--sk-accent);
+    color: white;
+    font-size: var(--sk-font-size-xs);
+    font-weight: 700;
+    line-height: 1;
+  }
+</style>

--- a/frontend/src/components/ToolStrip.svelte
+++ b/frontend/src/components/ToolStrip.svelte
@@ -40,7 +40,7 @@
   <div class="tool-section">
     <button
       class="tool-button"
-      class:active={filtersVisible}
+      class:active={filtersVisible || activeFilterCount > 0}
       aria-label="Toggle filters"
       title="Toggle filters"
       onclick={() => onToggleFilters?.()}
@@ -48,7 +48,7 @@
     >
       <span class="icon-stack">
         <Filter size={16} />
-        {#if activeFilterCount > 0}
+        {#if !filtersVisible && activeFilterCount > 0}
           <span class="badge">{activeFilterCount}</span>
         {/if}
       </span>

--- a/frontend/src/global.d.ts
+++ b/frontend/src/global.d.ts
@@ -1,0 +1,2 @@
+declare module '@fontsource-variable/inter';
+declare module '@fontsource-variable/jetbrains-mono';

--- a/frontend/src/lib/data-grid.test.ts
+++ b/frontend/src/lib/data-grid.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect } from 'vitest';
+import {
+  formatCellValue,
+  columnWidth,
+  sortStateToConfig,
+  getColumnDisplayName,
+  buildSortableColumn,
+} from './data-grid';
+import type { ColumnInfo } from './types';
+
+function col(overrides: Partial<ColumnInfo> = {}): ColumnInfo {
+  return {
+    name: 'test_col',
+    display_name: 'Test Col',
+    data_type: 'text',
+    display_type: 'Text',
+    is_nullable: true,
+    is_primary_key: false,
+    ...overrides,
+  };
+}
+
+describe('formatCellValue', () => {
+  it('returns null kind for null value', () => {
+    const result = formatCellValue(col(), null);
+    expect(result.kind).toBe('null');
+    expect(result.display).toBe('NULL');
+  });
+
+  it('returns null kind for undefined value', () => {
+    const result = formatCellValue(col(), undefined);
+    expect(result.kind).toBe('null');
+    expect(result.display).toBe('NULL');
+  });
+
+  describe('boolean', () => {
+    const boolCol = col({ data_type: 'boolean' });
+
+    it('formats true as Yes', () => {
+      const result = formatCellValue(boolCol, true);
+      expect(result.kind).toBe('boolean');
+      expect(result.display).toBe('Yes');
+      expect(result.booleanValue).toBe(true);
+    });
+
+    it('formats false as No', () => {
+      const result = formatCellValue(boolCol, false);
+      expect(result.kind).toBe('boolean');
+      expect(result.display).toBe('No');
+      expect(result.booleanValue).toBe(false);
+    });
+
+    it('formats string "true" as Yes', () => {
+      const result = formatCellValue(boolCol, 'true');
+      expect(result.display).toBe('Yes');
+      expect(result.booleanValue).toBe(true);
+    });
+
+    it('formats string "t" as Yes', () => {
+      const result = formatCellValue(boolCol, 't');
+      expect(result.display).toBe('Yes');
+      expect(result.booleanValue).toBe(true);
+    });
+
+    it('formats string "false" as No', () => {
+      const result = formatCellValue(boolCol, 'false');
+      expect(result.display).toBe('No');
+      expect(result.booleanValue).toBe(false);
+    });
+  });
+
+  describe('date-only', () => {
+    const dateCol = col({ data_type: 'date' });
+
+    it('formats a valid date string', () => {
+      const result = formatCellValue(dateCol, '2024-06-15');
+      expect(result.kind).toBe('timestamp');
+      expect(result.tooltip).toBe('2024-06-15');
+      // Display varies by locale but should contain "2024" and "15"
+      expect(result.display).toContain('15');
+      expect(result.display).toContain('2024');
+    });
+
+    it('falls through on invalid date', () => {
+      const result = formatCellValue(dateCol, 'not-a-date');
+      expect(result.kind).toBe('text');
+      expect(result.display).toBe('not-a-date');
+    });
+  });
+
+  describe('datetime', () => {
+    const tsCol = col({ data_type: 'timestamp without time zone' });
+
+    it('formats space-separated datetime (Safari fix: space replaced with T)', () => {
+      const result = formatCellValue(tsCol, '2024-01-15 14:30:00');
+      expect(result.kind).toBe('timestamp');
+      expect(result.tooltip).toBe('2024-01-15 14:30:00');
+      expect(result.display).toContain('2024');
+    });
+
+    it('formats ISO datetime', () => {
+      const result = formatCellValue(tsCol, '2024-01-15T14:30:00');
+      expect(result.kind).toBe('timestamp');
+    });
+
+    it('formats timestamp with time zone', () => {
+      const tzCol = col({ data_type: 'timestamp with time zone' });
+      const result = formatCellValue(tzCol, '2024-01-15T14:30:00Z');
+      expect(result.kind).toBe('timestamp');
+      expect(result.display).toContain('2024');
+    });
+
+    it('falls through on invalid datetime', () => {
+      const result = formatCellValue(tsCol, 'garbage');
+      expect(result.kind).toBe('text');
+    });
+
+    it('handles display_type datetime override', () => {
+      const customCol = col({ data_type: 'text', display_type: 'datetime' });
+      const result = formatCellValue(customCol, '2024-01-15T14:30:00');
+      expect(result.kind).toBe('timestamp');
+    });
+  });
+
+  describe('numeric (precision-safe)', () => {
+    const numericCol = col({ data_type: 'numeric' });
+
+    it('passes through string value without Number() cast', () => {
+      const bigValue = '12345678901234567890.12345';
+      const result = formatCellValue(numericCol, bigValue);
+      expect(result.kind).toBe('number');
+      expect(result.display).toBe(bigValue);
+    });
+  });
+
+  describe('number types', () => {
+    it('formats integer with locale', () => {
+      const intCol = col({ data_type: 'integer' });
+      const result = formatCellValue(intCol, 1234567);
+      expect(result.kind).toBe('number');
+      // Locale-dependent, but should be a string representation
+      expect(result.display).toBeTruthy();
+    });
+
+    it('formats real (float4)', () => {
+      const realCol = col({ data_type: 'real' });
+      const result = formatCellValue(realCol, 3.14);
+      expect(result.kind).toBe('number');
+    });
+
+    it('formats double precision', () => {
+      const dblCol = col({ data_type: 'double precision' });
+      const result = formatCellValue(dblCol, 3.14159265358979);
+      expect(result.kind).toBe('number');
+    });
+
+    it('falls through on NaN', () => {
+      const intCol = col({ data_type: 'integer' });
+      const result = formatCellValue(intCol, 'not-a-number');
+      expect(result.kind).toBe('text');
+    });
+
+    it('falls through on Infinity', () => {
+      const intCol = col({ data_type: 'integer' });
+      const result = formatCellValue(intCol, Infinity);
+      expect(result.kind).toBe('text');
+    });
+
+    it('handles bigint as string from backend (> 2^53)', () => {
+      const bigintCol = col({ data_type: 'bigint' });
+      const result = formatCellValue(bigintCol, '9007199254740993');
+      expect(result.kind).toBe('number');
+    });
+  });
+
+  describe('text fallback', () => {
+    it('formats plain text', () => {
+      const result = formatCellValue(col(), 'hello world');
+      expect(result.kind).toBe('text');
+      expect(result.display).toBe('hello world');
+    });
+
+    it('converts non-string values to string', () => {
+      const result = formatCellValue(col(), 42);
+      expect(result.kind).toBe('text');
+      expect(result.display).toBe('42');
+    });
+  });
+});
+
+describe('columnWidth', () => {
+  it('returns 92 for boolean', () => {
+    expect(columnWidth(col({ data_type: 'boolean' }))).toBe(92);
+  });
+
+  it('returns 110 for integer', () => {
+    expect(columnWidth(col({ data_type: 'integer' }))).toBe(110);
+  });
+
+  it('returns 132 for numeric', () => {
+    expect(columnWidth(col({ data_type: 'numeric' }))).toBe(132);
+  });
+
+  it('returns 190 for timestamp', () => {
+    expect(columnWidth(col({ data_type: 'timestamp with time zone' }))).toBe(190);
+  });
+
+  it('returns 280 for uuid', () => {
+    expect(columnWidth(col({ data_type: 'uuid' }))).toBe(280);
+  });
+
+  it('returns 160 for unknown type', () => {
+    expect(columnWidth(col({ data_type: 'custom_type' }))).toBe(160);
+  });
+});
+
+describe('sortStateToConfig', () => {
+  it('returns undefined when no sort active', () => {
+    expect(sortStateToConfig({ column: null, direction: null })).toBeUndefined();
+  });
+
+  it('returns config object when sort active', () => {
+    const result = sortStateToConfig({ column: 'name', direction: 'asc' });
+    expect(result).toEqual({ name: 'asc' });
+  });
+
+  it('returns undefined when column set but direction null', () => {
+    expect(sortStateToConfig({ column: 'name', direction: null })).toBeUndefined();
+  });
+});
+
+describe('getColumnDisplayName', () => {
+  it('returns display_name when set', () => {
+    expect(getColumnDisplayName(col({ display_name: 'Full Name' }))).toBe('Full Name');
+  });
+
+  it('falls back to name when display_name is empty', () => {
+    expect(getColumnDisplayName(col({ name: 'user_id', display_name: '' }))).toBe('user_id');
+  });
+});
+
+describe('buildSortableColumn', () => {
+  it('builds a column with correct prop and name', () => {
+    const c = col({ name: 'email', display_name: 'Email Address', data_type: 'text' });
+    const result = buildSortableColumn(c);
+    expect(result.prop).toBe('email');
+    expect(result.name).toBe('Email Address');
+    expect(result.sortable).toBe(true);
+  });
+
+  it('applies overrides', () => {
+    const c = col({ name: 'id', data_type: 'integer' });
+    const result = buildSortableColumn(c, { sortable: false });
+    expect(result.sortable).toBe(false);
+  });
+});

--- a/frontend/src/lib/data-grid.ts
+++ b/frontend/src/lib/data-grid.ts
@@ -1,0 +1,149 @@
+import type { ColumnRegular } from '@revolist/svelte-datagrid';
+import type { ColumnInfo, SortState } from './types';
+
+const INTEGER_TYPES = new Set([
+  'smallint',
+  'integer',
+  'bigint',
+]);
+
+const NUMBER_TYPES = new Set([
+  ...INTEGER_TYPES,
+  'real',
+  'double precision',
+  'numeric',
+  'decimal',
+]);
+
+const DATETIME_TYPES = new Set([
+  'date',
+  'timestamp',
+  'timestamp without time zone',
+  'timestamp with time zone',
+]);
+
+const formatter = new Intl.DateTimeFormat(undefined, {
+  month: 'short',
+  day: 'numeric',
+  hour: 'numeric',
+  minute: '2-digit',
+});
+
+export interface FormattedCellValue {
+  kind: 'null' | 'boolean' | 'number' | 'timestamp' | 'text';
+  display: string;
+  tooltip?: string;
+  booleanValue?: boolean;
+}
+
+export function columnWidth(col: ColumnInfo): number {
+  switch (col.data_type) {
+    case 'boolean':
+      return 92;
+    case 'smallint':
+    case 'integer':
+      return 110;
+    case 'bigint':
+    case 'real':
+    case 'double precision':
+    case 'numeric':
+      return 132;
+    case 'date':
+      return 132;
+    case 'time without time zone':
+    case 'time with time zone':
+      return 110;
+    case 'timestamp':
+    case 'timestamp without time zone':
+    case 'timestamp with time zone':
+      return 190;
+    case 'uuid':
+      return 280;
+    case 'json':
+    case 'jsonb':
+      return 250;
+    default:
+      return 160;
+  }
+}
+
+export function sortStateToConfig(
+  sortState: SortState,
+): Record<string, SortState['direction']> | undefined {
+  if (!sortState.column || !sortState.direction) {
+    return undefined;
+  }
+
+  return {
+    [sortState.column]: sortState.direction,
+  };
+}
+
+export function getColumnDisplayName(column: ColumnInfo): string {
+  return column.display_name || column.name;
+}
+
+export function formatCellValue(
+  column: ColumnInfo,
+  value: unknown,
+): FormattedCellValue {
+  if (value == null) {
+    return {
+      kind: 'null',
+      display: 'NULL',
+    };
+  }
+
+  if (column.data_type === 'boolean') {
+    const booleanValue = value === true || value === 'true' || value === 't';
+    return {
+      kind: 'boolean',
+      display: booleanValue ? 'Yes' : 'No',
+      booleanValue,
+    };
+  }
+
+  if (
+    DATETIME_TYPES.has(column.data_type) ||
+    column.display_type === 'datetime'
+  ) {
+    const raw = String(value);
+    const parsed = new Date(raw);
+
+    if (!Number.isNaN(parsed.getTime())) {
+      return {
+        kind: 'timestamp',
+        display: formatter.format(parsed),
+        tooltip: raw,
+      };
+    }
+  }
+
+  if (NUMBER_TYPES.has(column.data_type)) {
+    const numericValue = typeof value === 'number' ? value : Number(value);
+    if (Number.isFinite(numericValue)) {
+      return {
+        kind: 'number',
+        display: numericValue.toLocaleString(),
+      };
+    }
+  }
+
+  return {
+    kind: 'text',
+    display: String(value),
+  };
+}
+
+export function buildSortableColumn(
+  column: ColumnInfo,
+  overrides: Partial<ColumnRegular> = {},
+): ColumnRegular {
+  return {
+    prop: column.name,
+    name: getColumnDisplayName(column),
+    size: columnWidth(column),
+    sortable: true,
+    ...overrides,
+  };
+}

--- a/frontend/src/lib/data-grid.ts
+++ b/frontend/src/lib/data-grid.ts
@@ -17,7 +17,6 @@ const NUMBER_TYPES = new Set([
 // Display as right-aligned numbers with tabular-nums but skip Number() casting.
 const NUMERIC_TEXT_TYPES = new Set([
   'numeric',
-  'decimal',
 ]);
 
 const DATE_ONLY_TYPES = new Set([

--- a/frontend/src/lib/data-grid.ts
+++ b/frontend/src/lib/data-grid.ts
@@ -15,14 +15,24 @@ const NUMBER_TYPES = new Set([
   'decimal',
 ]);
 
-const DATETIME_TYPES = new Set([
+const DATE_ONLY_TYPES = new Set([
   'date',
+]);
+
+const DATETIME_TYPES = new Set([
   'timestamp',
   'timestamp without time zone',
   'timestamp with time zone',
 ]);
 
+const dateFormatter = new Intl.DateTimeFormat(undefined, {
+  year: 'numeric',
+  month: 'short',
+  day: 'numeric',
+});
+
 const formatter = new Intl.DateTimeFormat(undefined, {
+  year: 'numeric',
   month: 'short',
   day: 'numeric',
   hour: 'numeric',
@@ -101,6 +111,21 @@ export function formatCellValue(
       display: booleanValue ? 'Yes' : 'No',
       booleanValue,
     };
+  }
+
+  if (DATE_ONLY_TYPES.has(column.data_type)) {
+    const raw = String(value);
+    // Append local time to prevent UTC midnight being shifted to the previous day
+    // for users west of UTC (ECMAScript parses bare date strings as UTC midnight).
+    const parsed = new Date(`${raw}T00:00:00`);
+
+    if (!Number.isNaN(parsed.getTime())) {
+      return {
+        kind: 'timestamp',
+        display: dateFormatter.format(parsed),
+        tooltip: raw,
+      };
+    }
   }
 
   if (

--- a/frontend/src/lib/data-grid.ts
+++ b/frontend/src/lib/data-grid.ts
@@ -13,6 +13,13 @@ const NUMBER_TYPES = new Set([
   'double precision',
 ]);
 
+// Types where the backend sends a full-precision string to avoid JS float truncation.
+// Display as right-aligned numbers with tabular-nums but skip Number() casting.
+const NUMERIC_TEXT_TYPES = new Set([
+  'numeric',
+  'decimal',
+]);
+
 const DATE_ONLY_TYPES = new Set([
   'date',
 ]);
@@ -141,6 +148,14 @@ export function formatCellValue(
         tooltip: raw,
       };
     }
+  }
+
+  if (NUMERIC_TEXT_TYPES.has(column.data_type)) {
+    // Backend sends full-precision string — display as-is to avoid float truncation.
+    return {
+      kind: 'number',
+      display: String(value),
+    };
   }
 
   if (NUMBER_TYPES.has(column.data_type)) {

--- a/frontend/src/lib/data-grid.ts
+++ b/frontend/src/lib/data-grid.ts
@@ -11,8 +11,6 @@ const NUMBER_TYPES = new Set([
   ...INTEGER_TYPES,
   'real',
   'double precision',
-  'numeric',
-  'decimal',
 ]);
 
 const DATE_ONLY_TYPES = new Set([

--- a/frontend/src/lib/data-grid.ts
+++ b/frontend/src/lib/data-grid.ts
@@ -133,7 +133,8 @@ export function formatCellValue(
     column.display_type === 'datetime'
   ) {
     const raw = String(value);
-    const parsed = new Date(raw);
+    // Replace space with T for ISO 8601 compliance — Safari rejects "2024-01-15 14:30:00"
+    const parsed = new Date(raw.replace(' ', 'T'));
 
     if (!Number.isNaN(parsed.getTime())) {
       return {

--- a/frontend/src/lib/mock.test.ts
+++ b/frontend/src/lib/mock.test.ts
@@ -52,6 +52,36 @@ describe('mockFetchRows', () => {
     expect(filtered.total_rows).toBeLessThanOrEqual(all.total_rows);
   });
 
+  it('filters rows by column filters', () => {
+    const filtered = mockFetchRows('users', {
+      filters: { name: 'Alice' },
+    });
+
+    expect(filtered.total_rows).toBeGreaterThan(0);
+    expect(
+      filtered.rows.every((row) =>
+        String(row.name).toLowerCase().includes('alice'),
+      ),
+    ).toBe(true);
+  });
+
+  it('combines multiple column filters with AND logic', () => {
+    const filtered = mockFetchRows('users', {
+      filters: {
+        name: 'Alice',
+        email: 'alice.chen',
+      },
+    });
+
+    expect(filtered.total_rows).toBeGreaterThan(0);
+    expect(
+      filtered.rows.every((row) =>
+        String(row.name).toLowerCase().includes('alice') &&
+        String(row.email).toLowerCase().includes('alice.chen'),
+      ),
+    ).toBe(true);
+  });
+
   it('defaults page to 1 and page_size to 50', () => {
     const result = mockFetchRows('users');
     expect(result.page).toBe(1);

--- a/frontend/src/lib/mock.ts
+++ b/frontend/src/lib/mock.ts
@@ -430,6 +430,7 @@ export function mockFetchRows(
     sort_column?: string;
     sort_direction?: string;
     search?: string;
+    filters?: Record<string, string>;
   },
 ): QueryResult {
   const page = params?.page ?? 1;
@@ -447,6 +448,20 @@ export function mockFetchRows(
         String(v ?? '').toLowerCase().includes(q),
       ),
     );
+  }
+
+  if (params?.filters) {
+    const activeFilters = Object.entries(params.filters).filter(
+      ([, value]) => value.trim().length > 0,
+    );
+
+    if (activeFilters.length > 0) {
+      rows = rows.filter((row) =>
+        activeFilters.every(([column, value]) =>
+          String(row[column] ?? '').toLowerCase().includes(value.toLowerCase()),
+        ),
+      );
+    }
   }
 
   if (params?.sort_column) {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -21,6 +21,15 @@ export interface QueryResult {
   page_size: number;
 }
 
+export type SortDirection = 'asc' | 'desc';
+
+export interface SortState {
+  column: string | null;
+  direction: SortDirection | null;
+}
+
+export type FilterState = Record<string, string>;
+
 export interface TablesResponse {
   tables: TableInfo[];
 }

--- a/frontend/src/theme/tokens.css
+++ b/frontend/src/theme/tokens.css
@@ -56,6 +56,7 @@
   /* Sidebar */
   --sk-sidebar-width: 210px;
   --sk-sidebar-collapsed: 48px;
+  --sk-toolstrip-width: 40px;
 
   /* Zebra striping */
   --sk-row-alt: rgba(245, 240, 235, 0.3);

--- a/frontend/src/theme/tokens.css
+++ b/frontend/src/theme/tokens.css
@@ -5,7 +5,10 @@
   --sk-accent: #00A9A5;
   --sk-muted: #8a7a6c;
   --sk-secondary: #a0917f;
+  --sk-secondary-strong: #556977;
   --sk-faded: #b0a090;
+  --sk-boolean-true: #15803d;
+  --sk-boolean-false: #b91c1c;
 
   /* Glass surfaces */
   --sk-glass-sidebar: rgba(255, 255, 255, 0.5);
@@ -60,4 +63,11 @@
 
   /* Zebra striping */
   --sk-row-alt: rgba(245, 240, 235, 0.3);
+  --sk-null-hatch: repeating-linear-gradient(
+    -45deg,
+    rgba(47, 72, 88, 0.05),
+    rgba(47, 72, 88, 0.05) 4px,
+    rgba(255, 255, 255, 0.4) 4px,
+    rgba(255, 255, 255, 0.4) 8px
+  );
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -375,7 +375,11 @@ fn pg_value_to_csv_string(
             .try_get::<i64, _>(col)
             .map(|v| v.to_string())
             .unwrap_or_default(),
-        "real" | "double precision" => row
+        "real" => row
+            .try_get::<f32, _>(col)
+            .map(|v| v.to_string())
+            .unwrap_or_default(),
+        "double precision" => row
             .try_get::<f64, _>(col)
             .map(|v| v.to_string())
             .unwrap_or_default(),

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -229,13 +229,20 @@ async fn export_csv(
     let display_table = display_name_table(&table, &state.config.display)
         .replace(' ', "_")
         .to_lowercase();
-    let sanitized = display_table
+    let sanitized: String = display_table
         .replace('"', "")
         .replace('\\', "")
         .replace(';', "")
         .replace('\r', "")
-        .replace('\n', "");
-    let filename = format!("{sanitized}.csv");
+        .replace('\n', "")
+        .chars()
+        .filter(|c| c.is_ascii())
+        .collect();
+    let filename = if sanitized.is_empty() {
+        "export.csv".to_string()
+    } else {
+        format!("{sanitized}.csv")
+    };
 
     // Owned values for the spawned task
     let sort_column = params.sort_column.clone();

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -231,6 +231,7 @@ async fn export_csv(
         .to_lowercase();
     let sanitized = display_table
         .replace('"', "")
+        .replace('\\', "")
         .replace(';', "")
         .replace('\r', "")
         .replace('\n', "");

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -165,9 +165,10 @@ pub async fn get_columns_bulk(
     Ok(result)
 }
 
-/// Validate that a name contains only alphanumeric characters and underscores.
+/// Validate that a name is safe for use as a double-quoted SQL identifier.
+/// Allows alphanumeric, underscore, hyphen, and space — all safe inside `"..."`.
 fn is_valid_identifier(name: &str) -> bool {
-    !name.is_empty() && name.chars().all(|c| c.is_alphanumeric() || c == '_')
+    !name.is_empty() && name.chars().all(|c| c.is_alphanumeric() || c == '_' || c == '-' || c == ' ')
 }
 
 /// Shared WHERE clause and bind values builder for query_rows and export.
@@ -457,19 +458,21 @@ mod tests {
     use super::*;
 
     #[test]
-    fn valid_identifier_accepts_alphanumeric_underscore() {
+    fn valid_identifier_accepts_safe_chars() {
         assert!(is_valid_identifier("vehicle_id"));
         assert!(is_valid_identifier("col1"));
         assert!(is_valid_identifier("_private"));
         assert!(is_valid_identifier("CamelCase"));
+        assert!(is_valid_identifier("col-name"));
+        assert!(is_valid_identifier("col name"));
+        assert!(is_valid_identifier("my-table"));
     }
 
     #[test]
     fn valid_identifier_rejects_special_chars() {
-        assert!(!is_valid_identifier("col-name"));
         assert!(!is_valid_identifier("col.name"));
-        assert!(!is_valid_identifier("col name"));
         assert!(!is_valid_identifier("col;DROP TABLE"));
+        assert!(!is_valid_identifier("col\"name"));
         assert!(!is_valid_identifier(""));
     }
 

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -207,7 +207,7 @@ fn build_query_clauses(
     if has_search {
         let text_cols: Vec<String> = columns
             .iter()
-            .filter(|c| is_text_type(&c.data_type))
+            .filter(|c| is_text_type(&c.data_type) && is_valid_identifier(&c.name))
             .map(|c| format!("\"{}\"::text ILIKE '%' || ${param_idx} || '%'", c.name))
             .collect();
 
@@ -404,11 +404,24 @@ fn pg_value_to_json(row: &sqlx::postgres::PgRow, col: &str, data_type: &str) -> 
             .unwrap_or(Value::Null),
         "bigint" => row
             .try_get::<i64, _>(col)
-            .map(Value::from)
+            .map(|v| {
+                // Values beyond ±2^53 lose precision in JavaScript's float64 JSON.parse.
+                // Serialize as string to preserve full i64 range.
+                if v.unsigned_abs() > (1u64 << 53) {
+                    Value::String(v.to_string())
+                } else {
+                    Value::from(v)
+                }
+            })
             .unwrap_or(Value::Null),
         "real" => row
             .try_get::<f32, _>(col)
-            .map(|v| Value::from(v as f64))
+            .map(|v| {
+                // Parse via f32's string repr to avoid f64 widening artifacts
+                // (e.g., 3.14f32 as f64 → 3.140000104904175)
+                let clean: f64 = v.to_string().parse().unwrap_or(v as f64);
+                Value::from(clean)
+            })
             .unwrap_or(Value::Null),
         "double precision" => row
             .try_get::<f64, _>(col)

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -218,14 +218,37 @@ fn build_query_clauses(
         }
     }
 
-    // Per-column filter conditions (AND-ed, ILIKE with %value%)
+    // Per-column filter conditions (AND-ed)
+    // Boolean columns use = TRUE/FALSE instead of ILIKE to match Yes/No display.
+    let column_types: std::collections::HashMap<&str, &str> = columns
+        .iter()
+        .map(|c| (c.name.as_str(), c.data_type.as_str()))
+        .collect();
+
     let mut filter_entries: Vec<_> = filters.iter().collect();
     filter_entries.sort_by_key(|(k, _)| k.as_str());
 
     for (col_name, value) in &filter_entries {
-        conditions.push(format!("\"{}\"::text ILIKE ${param_idx}", col_name));
-        bind_values.push(format!("%{value}%"));
-        param_idx += 1;
+        let col_type = column_types.get(col_name.as_str()).copied().unwrap_or("");
+        if col_type == "boolean" {
+            // Map user-friendly input to SQL boolean
+            let normalized = value.trim().to_lowercase();
+            let bool_val = match normalized.as_str() {
+                "yes" | "true" | "t" | "1" => Some(true),
+                "no" | "false" | "f" | "0" => Some(false),
+                _ => None,
+            };
+            if let Some(b) = bool_val {
+                conditions.push(format!("\"{}\" = {}", col_name, if b { "TRUE" } else { "FALSE" }));
+            } else {
+                // Non-boolean input on a boolean column → no rows match
+                conditions.push("FALSE".to_string());
+            }
+        } else {
+            conditions.push(format!("\"{}\"::text ILIKE ${param_idx}", col_name));
+            bind_values.push(format!("%{value}%"));
+            param_idx += 1;
+        }
     }
 
     let where_clause = if conditions.is_empty() {

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -383,7 +383,11 @@ fn pg_value_to_json(row: &sqlx::postgres::PgRow, col: &str, data_type: &str) -> 
             .try_get::<i64, _>(col)
             .map(Value::from)
             .unwrap_or(Value::Null),
-        "real" | "double precision" => row
+        "real" => row
+            .try_get::<f32, _>(col)
+            .map(|v| Value::from(v as f64))
+            .unwrap_or(Value::Null),
+        "double precision" => row
             .try_get::<f64, _>(col)
             .map(Value::from)
             .unwrap_or(Value::Null),


### PR DESCRIPTION
## Summary
- Sidebar table list with client-side search filter for quick navigation across 20+ tables
- RevoGrid data grid as dumb renderer with CSS-based virtual scrolling, custom column headers
- Click-to-sort columns with three-state cycle (asc/desc/unsorted), server-side sort
- Per-column text filters inside headers, toggled from new left tool strip, 300ms debounce, AND logic
- Type-aware cell formatting: timestamps, boolean badges, locale numbers, NULL hatched indicators
- New vertical tool strip component between sidebar and grid for data manipulation controls
- Status bar verification (already functional from Epic 2)

## Spec
See `data-grid-table-navigation-spec.md` in the branch root for full acceptance criteria, technical plan, and task breakdown.

## Sub-issues
- #16 Collapsible sidebar with table search
- #17 RevoGrid data grid with virtual scrolling
- #18 Click-to-sort columns
- #19 Per-column text filter inputs
- #20 Auto display formatting for cell types
- #21 Status bar with pagination controls

## Test plan
- [ ] Grid renders with virtual scrolling active in mock mode (just dev-mock)
- [ ] Click column header cycles through asc/desc/unsorted with server re-fetch
- [ ] Toggle filter row from tool strip; type in filter input; debounced fetch with filter.{col} params
- [ ] Multiple filters combine with AND logic
- [ ] Timestamps show friendly format with ISO tooltip
- [ ] Booleans render as colored Yes/No badges
- [ ] NULL cells show dim italic text on hatched background
- [ ] Sidebar table search filters list instantly
- [ ] Status bar shows correct "Showing X-Y of N" with pagination
- [ ] Single binary build succeeds (just build)
- [ ] All tests pass (cargo test, npm run check, npm run test)

Closes #3