### PR TITLE
fix(ci): apply fmt + widen release workflow triggers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,16 @@
 name: Release Management
 
 on:
-    pull_request:
+    # Fires on any push to release (merge commits, direct pushes, tag-free cherries)
+    # as well as explicit manual dispatch. The prior pull_request:closed trigger
+    # silently no-ops in some merge paths, so we widen the surface here.
+    push:
         branches:
             - release
-        types: [closed]
+    workflow_dispatch:
 
 jobs:
     create-release:
-        if: github.event.pull_request.merged == true
         runs-on: ubuntu-latest
         permissions:
             contents: write

--- a/src/config.rs
+++ b/src/config.rs
@@ -544,7 +544,12 @@ subtitle = "Fleet Telemetry"
     #[test]
     fn column_display_name_uses_title_case_heuristic() {
         assert_eq!(
-            display_name_column("public", "my_table", "some_column", &DisplayConfig::default()),
+            display_name_column(
+                "public",
+                "my_table",
+                "some_column",
+                &DisplayConfig::default()
+            ),
             "Some Column"
         );
     }
@@ -552,7 +557,12 @@ subtitle = "Fleet Telemetry"
     #[test]
     fn column_display_name_drops_id_suffix() {
         assert_eq!(
-            display_name_column("public", "vehicles_log", "supervisor_id", &DisplayConfig::default()),
+            display_name_column(
+                "public",
+                "vehicles_log",
+                "supervisor_id",
+                &DisplayConfig::default()
+            ),
             "Supervisor"
         );
     }
@@ -782,10 +792,7 @@ auth_method = "key"
 known_hosts = "strict"
 "#;
         let config = AppConfig::parse(toml).expect("strict policy should parse");
-        assert_eq!(
-            config.ssh.unwrap().known_hosts,
-            KnownHostsPolicy::Strict
-        );
+        assert_eq!(config.ssh.unwrap().known_hosts, KnownHostsPolicy::Strict);
     }
 
     #[test]


### PR DESCRIPTION
Two CI hotfixes bundled together.

## Changes

1. `cargo fmt` applied to `src/config.rs` test bodies (pre-existing drift that was failing CI on main).
2. `release.yml` trigger widened from `pull_request: closed` → `push: release` + `workflow_dispatch` fallback, so merge commits reliably fire the release workflow. The prior trigger silently no-opped on the v26.5.0.2/.3 merge.

## Test plan

- [x] `cargo fmt --check` passes locally
- [x] `cargo test` — 66/66 pass
- [ ] CI green on this PR
- [ ] Next release merge into `release` auto-triggers the workflow