### PR TITLE
ci: extend CI to canonical template-repo superset

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -1,0 +1,62 @@
+name: "[Epic] Epic"
+description: Track a large body of work spanning multiple tasks and features
+title: "[Epic]: "
+labels: ["epic"]
+body:
+    - type: markdown
+      attributes:
+          value: |
+              Create an Epic to group a large body of work spanning multiple Tasks and Features. Epics branch from `main` and when merged back to `main` will bump the **Major** version (resetting Minor and Patch to 0: YY.**X**.0.0). The target branch will be rebased before merge to ensure a linear history.
+
+              **Hierarchical Workflow**: Add Tasks and Features as sub-issues of this Epic so their branches automatically slot under the epic branch for coordinated delivery.
+
+    - type: input
+      id: branch_off
+      attributes:
+          label: Branch off
+          description: |
+              Optional. The base branch this issue's branch and PR should target.
+              Leave as `main` for the default. Set to a specific branch name (e.g.
+              `feature/149-new-trip-flow`) when this work is a sub-task of an
+              existing in-flight branch and the auto-handler should slot it under
+              that branch instead of `main`.
+              Parsed by `.github/workflows/issue-branch-handler.yml`.
+          placeholder: main
+          value: main
+      validations:
+          required: false
+
+    - type: textarea
+      id: description
+      attributes:
+          label: Description
+          description: A clear and concise description of the epic and the outcome it delivers.
+          placeholder: What is the goal of this epic, and why does it matter?
+      validations:
+          required: true
+
+    - type: textarea
+      id: scope_acceptance
+      attributes:
+          label: Scope & Acceptance Criteria
+          description: Define what is in and out of scope, and the criteria that mark this epic complete.
+          placeholder: |
+              **In scope:**
+              - ...
+
+              **Out of scope:**
+              - ...
+
+              **Acceptance criteria:**
+              - [ ] Criterion 1
+              - [ ] Criterion 2
+      validations:
+          required: true
+
+    - type: textarea
+      id: additional
+      attributes:
+          label: Additional context
+          description: Any other context, links, sub-issues, or technical notes.
+      validations:
+          required: false

--- a/.github/ISSUE_TEMPLATE/hotfix.yml
+++ b/.github/ISSUE_TEMPLATE/hotfix.yml
@@ -1,0 +1,54 @@
+name: "[Hotfix] Hotfix"
+description: Report an urgent production issue that needs an immediate fix
+title: "[Hotfix]: "
+labels: ["hotfix"]
+body:
+    - type: markdown
+      attributes:
+          value: |
+              Use a Hotfix for urgent production issues that need an immediate fix. Hotfixes branch from `main` and when merged back to `main` will append an alphabetic **Patch** suffix to the current version (e.g. YY.MM.X.Y**a**, then **b**, ...). The target branch will be rebased before merge to ensure a linear history.
+
+    - type: input
+      id: branch_off
+      attributes:
+          label: Branch off
+          description: |
+              Optional. The base branch this issue's branch and PR should target.
+              Leave as `main` for the default. Set to a specific branch name (e.g.
+              `feature/149-new-trip-flow`) when this work is a sub-task of an
+              existing in-flight branch and the auto-handler should slot it under
+              that branch instead of `main`.
+              Parsed by `.github/workflows/issue-branch-handler.yml`.
+          placeholder: main
+          value: main
+      validations:
+          required: false
+
+    - type: textarea
+      id: description
+      attributes:
+          label: Description
+          description: A clear and concise description of what is broken in production.
+          placeholder: What is broken, how does it manifest, and how can it be reproduced?
+      validations:
+          required: true
+
+    - type: textarea
+      id: impact
+      attributes:
+          label: Impact
+          description: Describe the impact on users and systems, and the urgency of the fix.
+          placeholder: |
+              - Affected users/systems: ...
+              - Severity: ...
+              - Workaround (if any): ...
+      validations:
+          required: true
+
+    - type: textarea
+      id: additional
+      attributes:
+          label: Additional context
+          description: Any other context, logs, stack traces, or links.
+      validations:
+          required: false

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,107 @@
+name: Publish Docker Image
+
+# OPT-IN, inert-by-default publish bridge.
+#
+# Builds and pushes to ghcr.io only when the repo actually ships a Dockerfile.
+# A tiny `detect` job checks for the Dockerfile and the `publish-docker` job runs
+# only when it is present (`needs.detect.outputs.present == 'true'`). hashFiles()
+# is deliberately NOT used in a job-level `if` — it needs a runner workspace and
+# is invalid there, which produces an Actions startup failure.
+#
+# Trigger: pushing a release tag (v*). The release workflow creates these tags.
+on:
+    push:
+        tags:
+            - 'v*'
+
+permissions:
+    contents: read
+    packages: write
+
+jobs:
+    detect:
+        runs-on: ubuntu-latest
+        outputs:
+            present: ${{ steps.check.outputs.present }}
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v6
+
+            - name: Detect Dockerfile
+              id: check
+              run: |
+                  if [ -f Dockerfile ]; then
+                    echo "present=true" >> "$GITHUB_OUTPUT"
+                    echo "Dockerfile found — image publish will run."
+                  else
+                    echo "present=false" >> "$GITHUB_OUTPUT"
+                    echo "No Dockerfile at repo root — docker publish is inert here."
+                  fi
+
+    publish-docker:
+        needs: detect
+        if: needs.detect.outputs.present == 'true'
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            packages: write
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v6
+
+            - name: Derive image name and tags from git tag
+              id: meta
+              run: |
+                  # GITHUB_REF_NAME is the tag, e.g. "v26.4.0.0". Strip the leading "v".
+                  RAW_TAG="${GITHUB_REF_NAME}"
+                  RELEASE_VERSION="${RAW_TAG#v}"
+
+                  # Image repository on GHCR, lowercased (registry requires lowercase).
+                  IMAGE="ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')"
+
+                  # Parse CalVer YY.Major.Minor.Patch[Suffix] -> major.minor floating tag.
+                  if [[ "$RELEASE_VERSION" =~ ^([0-9]{2})\.([0-9]+)\.([0-9]+)\.([0-9]+)([a-zA-Z]*)$ ]]; then
+                    MAJOR="${BASH_REMATCH[2]}"
+                    MINOR="${BASH_REMATCH[3]}"
+                  else
+                    echo "Tag '$RAW_TAG' is not in YY.Major.Minor.Patch[Suffix] form." >&2
+                    exit 1
+                  fi
+
+                  # Rolling 'latest', the full version, and a floating '{major}.{minor}' tag.
+                  # Deliberately NOT the commit SHA.
+                  TAGS="${IMAGE}:latest,${IMAGE}:${RELEASE_VERSION},${IMAGE}:${MAJOR}.${MINOR}"
+
+                  echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
+                  echo "version=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
+                  echo "major_minor=${MAJOR}.${MINOR}" >> "$GITHUB_OUTPUT"
+                  echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
+                  echo "Image: $IMAGE"
+                  echo "Tags: $TAGS"
+
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v3
+
+            - name: Log in to GitHub Container Registry
+              uses: docker/login-action@v3
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Build and push image
+              uses: docker/build-push-action@v6
+              with:
+                  context: .
+                  file: Dockerfile
+                  push: true
+                  tags: ${{ steps.meta.outputs.tags }}
+
+            - name: Summary
+              run: |
+                  echo "## Docker Publish Summary" >> "$GITHUB_STEP_SUMMARY"
+                  echo "" >> "$GITHUB_STEP_SUMMARY"
+                  echo "- **Image**: \`${{ steps.meta.outputs.image }}\`" >> "$GITHUB_STEP_SUMMARY"
+                  echo "- **Version tag**: \`${{ steps.meta.outputs.version }}\`" >> "$GITHUB_STEP_SUMMARY"
+                  echo "- **Floating tag**: \`${{ steps.meta.outputs.major_minor }}\`" >> "$GITHUB_STEP_SUMMARY"
+                  echo "- **Rolling tag**: \`latest\`" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/issue-branch-handler.yml
+++ b/.github/workflows/issue-branch-handler.yml
@@ -331,14 +331,14 @@ jobs:
                       }
 
             - name: Comment on issue
-              if: (github.event.action == 'opened' || github.event.action == 'labeled') && github.event.issue.state == 'open' && steps.create-pr.outputs.result != 'null'
+              if: (github.event.action == 'opened' || github.event.action == 'labeled') && github.event.issue.state == 'open' && steps.create-pr.outputs.pr_number
               uses: actions/github-script@v8
               env:
                   BRANCH_NAME: ${{ env.BRANCH_NAME }}
                   BASE_BRANCH: ${{ env.BASE_BRANCH }}
                   BASE_SOURCE: ${{ env.BASE_SOURCE }}
                   BASE_OVERRIDE_MISSING: ${{ env.BASE_OVERRIDE_MISSING }}
-                  PR_NUMBER: ${{ steps.create-pr.outputs.result }}
+                  PR_NUMBER: ${{ steps.create-pr.outputs.pr_number }}
               with:
                   script: |
                       const branchName = process.env.BRANCH_NAME;
@@ -379,7 +379,7 @@ jobs:
                         issue_number: context.issue.number,
                         owner: context.repo.owner,
                         repo: context.repo.repo,
-                        assignees: ['Kiriketsuki']
+                        assignees: ['${{ vars.ISSUE_ASSIGNEE || github.repository_owner }}']
                       });
 
             - name: Handle issue close

--- a/.github/workflows/manual-version-bump.yml
+++ b/.github/workflows/manual-version-bump.yml
@@ -12,6 +12,7 @@ on:
                     - major
                     - minor
                     - patch
+                    - hotfix
                     - exact
             exact_version:
                 description: "Exact version (only used when bump_type is 'exact')"
@@ -69,6 +70,7 @@ jobs:
                     MAJOR="${BASH_REMATCH[2]}"
                     MINOR="${BASH_REMATCH[3]}"
                     PATCH="${BASH_REMATCH[4]}"
+                    SUFFIX="${BASH_REMATCH[5]}"
                   else
                     echo "Error: Invalid version format: $CURRENT"
                     exit 1
@@ -94,6 +96,28 @@ jobs:
                     patch)
                       PATCH=$((PATCH + 1))
                       NEW_VERSION="$YY.$MAJOR.$MINOR.$PATCH"
+                      ;;
+                    hotfix)
+                      if [ -z "$SUFFIX" ]; then
+                        SUFFIX="a"
+                      else
+                        # Increment suffix as base-26: a..z, aa..az, ba..zz, aaa...
+                        SUFFIX=$(python3 -c "
+                  def inc(s):
+                      chars = list(s)
+                      i = len(chars) - 1
+                      while i >= 0:
+                          if chars[i] == 'z':
+                              chars[i] = 'a'
+                              i -= 1
+                          else:
+                              chars[i] = chr(ord(chars[i]) + 1)
+                              return ''.join(chars)
+                      return 'a' + ''.join(chars)
+                  print(inc('$SUFFIX'))
+                  ")
+                      fi
+                      NEW_VERSION="$YY.$MAJOR.$MINOR.$PATCH$SUFFIX"
                       ;;
                   esac
 

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,114 @@
+name: Publish npm Package
+
+# OPT-IN, inert-by-default publish bridge.
+#
+# Publishes to GitHub Packages only when the repo actually ships an npm package.
+# A tiny `detect` job checks for package.json and the `publish-npm` job runs only
+# when it is present (`needs.detect.outputs.present == 'true'`). hashFiles() is
+# deliberately NOT used in a job-level `if` — it needs a runner workspace and is
+# invalid there, which produces an Actions startup failure.
+#
+# Trigger: pushing a release tag (v*). The release workflow creates these tags.
+on:
+    push:
+        tags:
+            - 'v*'
+
+permissions:
+    contents: read
+    packages: write
+
+jobs:
+    detect:
+        runs-on: ubuntu-latest
+        outputs:
+            present: ${{ steps.check.outputs.present }}
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v6
+
+            - name: Detect package.json
+              id: check
+              run: |
+                  if [ -f package.json ]; then
+                    echo "present=true" >> "$GITHUB_OUTPUT"
+                    echo "package.json found — npm publish will run."
+                  else
+                    echo "present=false" >> "$GITHUB_OUTPUT"
+                    echo "No package.json at repo root — npm publish is inert here."
+                  fi
+
+    publish-npm:
+        needs: detect
+        if: needs.detect.outputs.present == 'true'
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            packages: write
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v6
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: '22'
+                  registry-url: 'https://npm.pkg.github.com'
+
+            - name: Convert CalVer VERSION to npm semver
+              id: version
+              run: |
+                  node scripts/version-package.mjs semver
+                  NPM_VERSION=$(node scripts/version-package.mjs print-semver)
+                  PKG_NAME=$(node -p "require('./package.json').name")
+                  echo "npm_version=$NPM_VERSION" >> "$GITHUB_OUTPUT"
+                  echo "pkg_name=$PKG_NAME" >> "$GITHUB_OUTPUT"
+                  echo "Resolved npm version: $NPM_VERSION"
+                  echo "Package name: $PKG_NAME"
+
+            - name: Check if version is already published
+              id: check
+              run: |
+                  NPM_VERSION="${{ steps.version.outputs.npm_version }}"
+                  PKG_NAME="${{ steps.version.outputs.pkg_name }}"
+                  if npm view "${PKG_NAME}@${NPM_VERSION}" version >/dev/null 2>&1; then
+                    echo "already_published=true" >> "$GITHUB_OUTPUT"
+                    echo "Version ${PKG_NAME}@${NPM_VERSION} is already published — skipping."
+                  else
+                    echo "already_published=false" >> "$GITHUB_OUTPUT"
+                    echo "Version ${PKG_NAME}@${NPM_VERSION} is not published — proceeding."
+                  fi
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Install dependencies and build
+              if: steps.check.outputs.already_published == 'false'
+              run: |
+                  if [ -f package-lock.json ]; then
+                    npm ci
+                  else
+                    npm install
+                  fi
+                  if node -e "process.exit(require('./package.json').scripts?.build ? 0 : 1)"; then
+                    npm run build
+                  else
+                    echo "No build script defined — skipping build."
+                  fi
+
+            - name: Publish to GitHub Packages
+              if: steps.check.outputs.already_published == 'false'
+              run: npm publish --tag latest
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Summary
+              run: |
+                  echo "## npm Publish Summary" >> "$GITHUB_STEP_SUMMARY"
+                  echo "" >> "$GITHUB_STEP_SUMMARY"
+                  echo "- **Package**: \`${{ steps.version.outputs.pkg_name }}\`" >> "$GITHUB_STEP_SUMMARY"
+                  echo "- **npm version**: \`${{ steps.version.outputs.npm_version }}\`" >> "$GITHUB_STEP_SUMMARY"
+                  if [ "${{ steps.check.outputs.already_published }}" = "true" ]; then
+                    echo "- ⏭️ Already published — skipped." >> "$GITHUB_STEP_SUMMARY"
+                  else
+                    echo "- ✅ Published to GitHub Packages." >> "$GITHUB_STEP_SUMMARY"
+                  fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -353,13 +353,45 @@ jobs:
             git push origin "$TAG_NAME"
           fi
 
+      - name: Generate changelog with git-cliff
+        id: git-cliff
+        uses: orhun/git-cliff-action@v4
+        with:
+          config: cliff.toml
+          args: --latest --github-repo "${{ github.repository }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compose release body
+        id: release-body
+        env:
+          SEEKI_BODY: ${{ needs.metadata.outputs.release_body }}
+          CLIFF_CONTENT: ${{ steps.git-cliff.outputs.content }}
+        run: |
+          set -euo pipefail
+
+          BODY_FILE="$(mktemp)"
+          printf '%s\n' "$SEEKI_BODY" > "$BODY_FILE"
+
+          # Append the git-cliff curated changelog when it produced content.
+          if [ -n "${CLIFF_CONTENT//[[:space:]]/}" ]; then
+            {
+              echo
+              echo "## Changelog"
+              echo
+              printf '%s\n' "$CLIFF_CONTENT"
+            } >> "$BODY_FILE"
+          fi
+
+          echo "body_path=$BODY_FILE" >> "$GITHUB_OUTPUT"
+
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ needs.metadata.outputs.tag_name }}
           target_commitish: ${{ needs.metadata.outputs.target_sha }}
           name: ${{ needs.metadata.outputs.release_name }}
-          body: ${{ needs.metadata.outputs.release_body }}
+          body_path: ${{ steps.release-body.outputs.body_path }}
           draft: false
           prerelease: ${{ needs.metadata.outputs.prerelease == 'true' }}
           fail_on_unmatched_files: true

--- a/.github/workflows/version-validation.yml
+++ b/.github/workflows/version-validation.yml
@@ -81,11 +81,27 @@ jobs:
 
                   if [ -n "$LATEST_TAG" ]; then
                     LATEST_VERSION="${LATEST_TAG#v}"
-                    if [ "$VERSION" = "$LATEST_VERSION" ]; then
-                      echo "Error: Version $VERSION is the same as latest tag $LATEST_TAG"
+
+                    # Normalize a version string so historical leading-zero-year
+                    # tags (e.g. v26.01.0.0) compare equal to canonical ones
+                    # (e.g. 26.1.0.0). Strip a leading 'v', then for each
+                    # dot-separated segment strip leading zeros from the numeric
+                    # prefix while preserving any trailing alphabetic suffix.
+                    # The python3 -c body stays on one logical line (list
+                    # comprehension), so it never dedents to column 0 and the
+                    # surrounding YAML block scalar remains valid.
+                    normalize_version() {
+                      python3 -c 'import re, sys; raw = sys.argv[1].strip(); raw = raw[1:] if raw[:1] in ("v", "V") else raw; segs = [(lambda m: (str(int(m.group(1))) if m.group(1) else "") + m.group(2) if m and (m.group(1) or m.group(2)) else s)(re.match(r"^(\d*)([A-Za-z]*)$", s)) for s in raw.split(".")]; print(".".join(segs))' "$1"
+                    }
+
+                    NORM_VERSION="$(normalize_version "$VERSION")"
+                    NORM_LATEST="$(normalize_version "$LATEST_VERSION")"
+
+                    if [ "$NORM_VERSION" = "$NORM_LATEST" ]; then
+                      echo "Error: Version $VERSION is the same as latest tag $LATEST_TAG (normalized: $NORM_VERSION == $NORM_LATEST)"
                       exit 1
                     fi
-                    echo "Version $VERSION differs from latest tag $LATEST_TAG"
+                    echo "Version $VERSION differs from latest tag $LATEST_TAG (normalized: $NORM_VERSION != $NORM_LATEST)"
                   else
                     echo "No previous tags found, skipping comparison."
                   fi

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,94 @@
+[changelog]
+header = ""
+body = """
+{%- macro remote_url() -%}
+  https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}
+{%- endmacro -%}
+
+{%- set priority = ["Features", "Bug Fixes", "Performance", "Refactor", "Documentation", "Testing", "Hotfix", "CI/CD", "Maintenance", "Reverted", "Other"] -%}
+{% for p in priority -%}
+{% for group, commits in commits | group_by(attribute="group") -%}
+{% if group == p %}
+### {{ group }}
+{% for commit in commits -%}
+- {% if commit.scope %}**{{ commit.scope }}**: {% endif -%}
+  {{- commit.message | split(pat="\n") | first | upper_first | trim -}}
+  {%- if commit.remote.username %} by @{{ commit.remote.username }}{%- endif -%}
+  {%- if commit.remote.pr_number %} in \
+  [#{{ commit.remote.pr_number }}]({{ self::remote_url() }}/pull/{{ commit.remote.pr_number }}){%- endif %}
+{% endfor %}
+{% endif -%}
+{% endfor -%}
+{% endfor -%}
+
+{%- if github -%}
+{%- if github.contributors | filter(attribute="is_first_time", value=true) | length != 0 %}
+
+### New Contributors
+{% for contributor in github.contributors | filter(attribute="is_first_time", value=true) -%}
+* @{{ contributor.username }} made their first contribution\
+  {%- if contributor.pr_number %} in \
+  [#{{ contributor.pr_number }}]({{ self::remote_url() }}/pull/{{ contributor.pr_number }}){%- endif %}
+{% endfor -%}
+{%- endif -%}
+{%- endif -%}
+
+{%- if version and previous.version and remote.github.owner %}
+
+**Full Changelog**: {{ self::remote_url() }}/compare/{{ previous.version }}...{{ version }}
+{%- endif %}
+"""
+footer = ""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = false
+split_commits = false
+commit_preprocessors = [
+    # Strip [skip ci] tags
+    { pattern = '\s*\[skip ci\]', replace = '' },
+    # Normalize legacy "[Type] Title" format -> conventional commit
+    { pattern = '(?i)^adding\s+\[feature\]:?\s*', replace = 'feat: ' },
+    { pattern = '(?i)^fixing\s+\[bug\]:?\s*', replace = 'fix: ' },
+    { pattern = '(?i)^implementing\s+\[task\]:?\s*', replace = 'chore: ' },
+    { pattern = '(?i)^adding\s+\[bug\]:?\s*', replace = 'fix: ' },
+    { pattern = '(?i)^adding\s+fix\s+', replace = 'fix: ' },
+    { pattern = '(?i)^adding\s+', replace = 'feat: ' },
+    { pattern = '(?i)^fixing\s+', replace = 'fix: ' },
+    { pattern = '(?i)^implementing\s+', replace = 'chore: ' },
+    # Normalize Revert messages
+    { pattern = '^Revert "(.+)"$', replace = 'revert: ${1}' },
+    # Clean up double-colon from normalization
+    { pattern = ':\s+:\s+', replace = ': ' },
+]
+commit_parsers = [
+    # Skip version bump / release noise
+    { message = '(?i)ci: release version', skip = true },
+    { message = '(?i)ci: manual version bump', skip = true },
+    { message = '(?i)ci: bump version', skip = true },
+    { message = '(?i)chore: bump version', skip = true },
+    { message = '(?i)ci: sync version', skip = true },
+    { message = '(?i)chore:.*version.*\[skip', skip = true },
+    { message = '(?i)chore:.*update version', skip = true },
+    { message = '(?i)^Merge', skip = true },
+
+    # Conventional commits
+    { message = '(?i)^feat', group = "Features" },
+    { message = '(?i)^fix', group = "Bug Fixes" },
+    { message = '(?i)^perf', group = "Performance" },
+    { message = '(?i)^refactor', group = "Refactor" },
+    { message = '(?i)^docs?[:(]', group = "Documentation" },
+    { message = '(?i)^test', group = "Testing" },
+    { message = '(?i)^hotfix', group = "Hotfix" },
+    { message = '(?i)^ci', group = "CI/CD" },
+    { message = '(?i)^style', group = "Maintenance" },
+    { message = '(?i)^chore', group = "Maintenance" },
+    { message = '(?i)^revert', group = "Reverted" },
+
+    # Catch-all
+    { message = '.*', group = "Other" },
+]
+filter_commits = true
+tag_pattern = "v[0-9].*"
+sort_commits = "newest"

--- a/scripts/version-package.mjs
+++ b/scripts/version-package.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+// Convert the repository's CalVer VERSION file (YY.Major.Minor.Patch[Suffix])
+// into an npm-legal semver and write it into package.json "version".
+//
+// Mapping:
+//   Major.Minor.Patch  -> semver core
+//   20YY (+ any suffix) -> prerelease metadata
+//
+//   26.4.0.0   -> 4.0.0-2026
+//   26.4.0.1a  -> 4.0.1-2026.a
+//
+// This script is OPT-IN and inert by default: if package.json is absent it is a
+// clean no-op (exit 0), so it is safe to run in a repo that ships no Node package.
+// It is also idempotent: writing the same version twice produces no change.
+//
+// Modes:
+//   semver        write the npm semver into package.json
+//   internal      write the raw CalVer string into package.json
+//   print-semver  print the npm semver to stdout (no file writes)
+
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const rootDir = resolve(fileURLToPath(new URL('.', import.meta.url)), '..')
+const versionFilePath = resolve(rootDir, 'VERSION')
+const packageJsonPath = resolve(rootDir, 'package.json')
+
+const CALVER_RE = /^([0-9]{2})\.([0-9]+)\.([0-9]+)\.([0-9]+)([a-zA-Z]*)$/
+
+function readInternalVersion() {
+  const version = readFileSync(versionFilePath, 'utf8').trim()
+
+  if (!CALVER_RE.test(version)) {
+    throw new Error(
+      `Invalid VERSION format: ${version}. Expected YY.Major.Minor.Patch[Suffix].`,
+    )
+  }
+
+  return version
+}
+
+function toSemver(version) {
+  const match = version.match(CALVER_RE)
+
+  if (!match) {
+    throw new Error(
+      `Cannot transform invalid internal version: ${version}. Expected YY.Major.Minor.Patch[Suffix].`,
+    )
+  }
+
+  const [, year, major, minor, patch, suffix] = match
+  let semver = `${Number(major)}.${Number(minor)}.${Number(patch)}-20${year}`
+
+  if (suffix) {
+    semver += `.${suffix}`
+  }
+
+  return semver
+}
+
+function readPackageVersion() {
+  const packageJson = readFileSync(packageJsonPath, 'utf8')
+  const match = packageJson.match(/"version"\s*:\s*"([^"]+)"/)
+  return match ? match[1] : null
+}
+
+function writePackageVersion(version) {
+  // Inert by default: with no package.json there is nothing to update.
+  if (!existsSync(packageJsonPath)) {
+    return
+  }
+
+  const current = readPackageVersion()
+
+  // Idempotent: skip the write when the version is already correct.
+  if (current === version) {
+    return
+  }
+
+  const packageJson = readFileSync(packageJsonPath, 'utf8')
+
+  if (current === null) {
+    throw new Error(
+      'package.json exists but has no "version" field to update.',
+    )
+  }
+
+  const updatedPackageJson = packageJson.replace(
+    /"version"\s*:\s*"[^"]+"/,
+    `"version": "${version}"`,
+  )
+
+  writeFileSync(packageJsonPath, updatedPackageJson)
+}
+
+function main() {
+  const mode = process.argv[2]
+  const internalVersion = readInternalVersion()
+
+  if (mode === 'semver') {
+    writePackageVersion(toSemver(internalVersion))
+    return
+  }
+
+  if (mode === 'internal') {
+    writePackageVersion(internalVersion)
+    return
+  }
+
+  if (mode === 'print-semver') {
+    process.stdout.write(toSemver(internalVersion))
+    return
+  }
+
+  throw new Error(`Unsupported mode: ${mode}. Use "semver", "internal", or "print-semver".`)
+}
+
+main()


### PR DESCRIPTION
Extends seeKi's CI/CD into the canonical template-repo superset while **preserving seeKi's identity** — the Rust binary release matrix, ci.yml, e2e.yml, and VERSION sync logic are all kept intact. This is an **additive superset**, not an overwrite.

Closes #98

## Files added (verbatim from template-repo)
- `cliff.toml` — git-cliff changelog config
- `.github/ISSUE_TEMPLATE/epic.yml`, `hotfix.yml`, `config.yml`
- `.github/workflows/publish-npm.yml`, `docker-publish.yml` — inert opt-in (detect-then-run guards; harmless no-ops for a Rust repo with no package.json/Dockerfile)
- `scripts/version-package.mjs` — CalVer→npm-semver bridge (inert without package.json)

## Files edited (canonical improvements, seeKi logic preserved)
- **release.yml**: integrate `orhun/git-cliff-action@v4` (config: `cliff.toml`, args: `--latest --github-repo`) for release NOTES; a `Compose release body` step combines seeKi's rich metadata body with `${{ steps.git-cliff.outputs.content }}`. seeKi's cross-platform Rust binary build/upload matrix and VERSION sync-from-main are untouched. Sync already precedes version read — no reorder needed.
- **manual-version-bump.yml**: add `hotfix` base-26 suffix bump option (a..z, aa..az, ...). Python heredoc copied verbatim from `version-bump.yml` (not dedented); regex now captures the existing suffix.
- **version-validation.yml**: leading-zero-year tag normalization so historical `v26.01.0.0` tags compare equal to canonical `26.1.0.0`.
- **issue-branch-handler.yml**: configurable assignee (`vars.ISSUE_ASSIGNEE || github.repository_owner`); normalize create-PR output reads from `result` to `pr_number`.

## Validation
- All 9 touched/added YAML files pass `yaml.safe_load`.
- All 6 workflows pass `actionlint -shellcheck=` CLEAN.
- `cliff.toml` passes python `tomllib`.
- Base-26 suffix and normalize_version logic runtime-verified.

## Test plan
- [ ] `validate-version` check passes on this PR.
- [ ] On a future merge to `release`, confirm git-cliff changelog appends under `## Changelog` in the GitHub release body, with Rust assets attached.
- [ ] Manual dispatch of `manual-version-bump.yml` with `hotfix` produces a suffix bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)