### PR TITLE
feat(tables): hide partition children and surface partitioned parents

### DIFF
--- a/frontend/src/components/TableList.svelte
+++ b/frontend/src/components/TableList.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Pencil, Search } from 'lucide-svelte';
+  import { ChevronRight, Layers, Pencil, Search } from 'lucide-svelte';
   import type { TableInfo } from '../lib/types';
 
   const MAX_DISPLAY_NAME_LENGTH = 64;
@@ -44,22 +44,79 @@
     return table.schema === 'public' ? table.name : `${table.schema}.${table.name}`;
   }
 
+  function tableKey(table: TableInfo): string {
+    return `${table.schema}.${table.name}`;
+  }
+
+  // Partition children group under their parent. A child whose parent is not
+  // in the list stays in the main list, so it never becomes unreachable.
+  let presentKeys = $derived(new Set(tables.map(tableKey)));
+
+  let partitionsByParent = $derived.by(() => {
+    const groups = new Map<string, TableInfo[]>();
+    for (const table of tables) {
+      const parent = table.partition_parent;
+      if (parent && presentKeys.has(parent)) {
+        const group = groups.get(parent) ?? [];
+        groups.set(parent, [...group, table]);
+      }
+    }
+    return groups;
+  });
+
+  let mainTables = $derived(
+    tables.filter((table) => !table.partition_parent || !presentKeys.has(table.partition_parent)),
+  );
+
+  let partitionCount = $derived(tables.length - mainTables.length);
+
+  let expandedParents = $state<Set<string>>(new Set());
+
+  function toggleExpanded(parentKey: string) {
+    const next = new Set(expandedParents);
+    if (next.has(parentKey)) {
+      next.delete(parentKey);
+    } else {
+      next.add(parentKey);
+    }
+    expandedParents = next;
+  }
+
   let search = $state('');
+
+  function matchesQuery(table: TableInfo, query: string): boolean {
+    return (
+      prettyLabel(table).toLowerCase().includes(query) ||
+      table.display_name.toLowerCase().includes(query)
+    );
+  }
+
   let filteredTables = $derived.by(() => {
     const query = search.trim().toLowerCase();
     if (!query) {
-      return tables;
+      return mainTables;
     }
 
-    return tables.filter(
+    // A parent also matches when one of its partitions matches.
+    return mainTables.filter(
       (table) =>
-        prettyLabel(table).toLowerCase().includes(query) ||
-        table.display_name.toLowerCase().includes(query),
+        matchesQuery(table, query) ||
+        (partitionsByParent.get(tableKey(table)) ?? []).some((p) => matchesQuery(p, query)),
     );
   });
 
-  function tableKey(table: TableInfo): string {
-    return `${table.schema}.${table.name}`;
+  // While searching, a parent whose partitions match auto-expands to the matches.
+  function visiblePartitions(parentKey: string): TableInfo[] {
+    const children = partitionsByParent.get(parentKey) ?? [];
+    const query = search.trim().toLowerCase();
+    if (!query) {
+      return expandedParents.has(parentKey) ? children : [];
+    }
+    const matching = children.filter((p) => matchesQuery(p, query));
+    if (matching.length > 0) {
+      return matching;
+    }
+    return expandedParents.has(parentKey) ? children : [];
   }
 
   let editingKey = $state<string | null>(null);
@@ -107,7 +164,9 @@
   {#if showHeader}
     <div class="section-header">
       <div class="section-title">Tables</div>
-      <div class="section-subtitle">{tables.length} available</div>
+      <div class="section-subtitle">
+        {mainTables.length} available{partitionCount > 0 ? ` · ${partitionCount} partitions` : ''}
+      </div>
     </div>
   {/if}
 
@@ -127,6 +186,7 @@
   <div class="list-items" data-testid="table-list-items">
     {#if filteredTables.length > 0}
       {#each filteredTables as table (tableKey(table))}
+        {@const hasPartitions = (partitionsByParent.get(tableKey(table)) ?? []).length > 0}
         <div
           class="table-row"
           class:active={selectedSchema === table.schema && selectedTable === table.name}
@@ -147,15 +207,36 @@
               data-testid={`table-item-rename-input-${tableKey(table)}`}
             />
           {:else}
+            {#if hasPartitions}
+              <button
+                type="button"
+                class="partition-toggle"
+                class:expanded={expandedParents.has(tableKey(table))}
+                aria-label={`Toggle partitions of ${prettyLabel(table)}`}
+                aria-expanded={expandedParents.has(tableKey(table))}
+                onclick={() => toggleExpanded(tableKey(table))}
+                data-testid={`partition-toggle-${tableKey(table)}`}
+              >
+                <ChevronRight size={12} />
+              </button>
+            {/if}
             <button
               type="button"
               class="table-item"
+              class:has-toggle={hasPartitions}
               onclick={() => onSelect(table)}
               ondblclick={() => startEdit(table)}
-              title={`${table.schema}.${table.name}`}
+              title={table.is_partitioned
+                ? `${table.schema}.${table.name} — partitioned table, all partitions merged`
+                : `${table.schema}.${table.name}`}
               data-testid={`table-item-${tableKey(table)}`}
             >
               <span class="table-item-name">{prettyLabel(table)}</span>
+              {#if table.is_partitioned}
+                <span class="partition-badge" title="Partitioned table">
+                  <Layers size={11} />
+                </span>
+              {/if}
               {#if table.row_count_estimate != null}
                 <span class="table-item-count">{table.row_count_estimate.toLocaleString()}</span>
               {/if}
@@ -174,6 +255,25 @@
             </button>
           {/if}
         </div>
+        {#each visiblePartitions(tableKey(table)) as partition (tableKey(partition))}
+          <div
+            class="table-row partition-row"
+            class:active={selectedSchema === partition.schema && selectedTable === partition.name}
+          >
+            <button
+              type="button"
+              class="table-item partition-item"
+              onclick={() => onSelect(partition)}
+              title={`${partition.schema}.${partition.name} — partition of ${table.schema}.${table.name}`}
+              data-testid={`table-item-${tableKey(partition)}`}
+            >
+              <span class="table-item-name">{partition.name}</span>
+              {#if partition.row_count_estimate != null}
+                <span class="table-item-count">{partition.row_count_estimate.toLocaleString()}</span>
+              {/if}
+            </button>
+          </div>
+        {/each}
       {/each}
     {:else}
       <div class="empty-state" data-testid="table-list-empty">
@@ -369,6 +469,60 @@
   .table-item-edit-input:focus {
     border-color: rgba(var(--marble-active-rgb), 0.4);
     box-shadow: 0 0 0 2px var(--sk-ring);
+  }
+
+  /* chevron: rotates 90deg when the partition group is expanded */
+  .partition-toggle {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+    margin-left: var(--sk-space-xs);
+    border: none;
+    background: none;
+    border-radius: var(--sk-radius-sm);
+    color: var(--sk-muted);
+    cursor: pointer;
+    transition: transform 120ms ease, background 120ms ease;
+  }
+
+  .partition-toggle.expanded {
+    transform: rotate(90deg);
+  }
+
+  .partition-toggle:hover {
+    background: var(--sk-active-tint-soft);
+    color: var(--sk-text);
+  }
+
+  .partition-toggle:focus-visible {
+    outline: 2px solid var(--sk-focus-ring);
+    outline-offset: 2px;
+  }
+
+  /* the parent button loses left padding when a chevron precedes it */
+  .table-item.has-toggle {
+    padding-left: var(--sk-space-xs);
+  }
+
+  .partition-badge {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    color: var(--sk-muted);
+  }
+
+  /* partition child rows: indented, slightly muted */
+  .partition-row .partition-item {
+    padding-left: calc(var(--sk-space-md) + 20px);
+    font-size: var(--sk-font-size-sm);
+    color: var(--sk-secondary-strong);
+  }
+
+  .partition-row.active .partition-item {
+    color: var(--sk-ink-strong);
   }
 
   .empty-state {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -3,6 +3,10 @@ export interface TableInfo {
   name: string;
   display_name: string;
   row_count_estimate: number | null;
+  /** True when the relation is a partitioned parent table. */
+  is_partitioned?: boolean;
+  /** Qualified "schema.name" of the parent when the relation is a partition child. */
+  partition_parent?: string | null;
 }
 
 export interface ColumnInfo {

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -117,8 +117,12 @@ async fn get_display_config(
     let settings = load_settings_map(&store).await?;
     let schemas = state.config.database.effective_schemas();
     let all_tables = state.db.list_tables(&schemas).await?;
+    // Partition children reuse the parent's column set, so the display config
+    // skips them. This keeps the bulk column fetch small on heavily
+    // partitioned databases.
     let allowed_tables: Vec<_> = all_tables
         .into_iter()
+        .filter(|t| t.partition_parent.is_none())
         .filter(|t| state.config.tables.allows(&t.schema, &t.name))
         .collect();
 
@@ -256,6 +260,8 @@ async fn list_tables(
                 "name": t.name,
                 "display_name": display,
                 "row_count_estimate": t.row_count_estimate,
+                "is_partitioned": t.is_partitioned,
+                "partition_parent": t.partition_parent,
             })
         })
         .collect();

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -24,6 +24,10 @@ pub struct TableInfo {
     pub schema: String,
     pub name: String,
     pub row_count_estimate: Option<i64>,
+    /// True when this relation is a declaratively partitioned parent (relkind 'p').
+    pub is_partitioned: bool,
+    /// Qualified "schema.name" of the parent when this relation is a partition child.
+    pub partition_parent: Option<String>,
 }
 
 impl TableInfo {

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -64,10 +64,19 @@ pub async fn test_connection(
         SELECT
             n.nspname AS schema_name,
             c.relname AS table_name,
-            c.reltuples::bigint AS row_estimate
+            CASE
+                WHEN c.relkind = 'p' THEN (
+                    SELECT COALESCE(SUM(GREATEST(ch.reltuples, 0))::bigint, 0)
+                    FROM pg_inherits i
+                    JOIN pg_class ch ON ch.oid = i.inhrelid
+                    WHERE i.inhparent = c.oid
+                )
+                ELSE c.reltuples::bigint
+            END AS row_estimate
         FROM pg_class c
         JOIN pg_namespace n ON n.oid = c.relnamespace
-        WHERE c.relkind = 'r'
+        WHERE c.relkind IN ('r', 'p')
+          AND NOT c.relispartition
         ORDER BY n.nspname, c.relname
         "#,
     )
@@ -112,7 +121,7 @@ pub async fn list_schemas(pool: &PgPool) -> anyhow::Result<Vec<SchemaPreview>> {
         r#"
         SELECT
             n.nspname AS schema_name,
-            COUNT(c.oid) FILTER (WHERE c.relkind = 'r') AS table_count
+            COUNT(c.oid) FILTER (WHERE c.relkind IN ('r', 'p') AND NOT c.relispartition) AS table_count
         FROM pg_namespace n
         LEFT JOIN pg_class c ON c.relnamespace = n.oid
         WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
@@ -147,11 +156,25 @@ pub async fn list_tables(pool: &PgPool, schemas: &[String]) -> anyhow::Result<Ve
         SELECT
             n.nspname AS schema_name,
             c.relname AS table_name,
-            c.reltuples::bigint AS row_estimate
+            (c.relkind = 'p') AS is_partitioned,
+            pn.nspname AS parent_schema,
+            pc.relname AS parent_name,
+            CASE
+                WHEN c.relkind = 'p' THEN (
+                    SELECT COALESCE(SUM(GREATEST(ch.reltuples, 0))::bigint, 0)
+                    FROM pg_inherits ci
+                    JOIN pg_class ch ON ch.oid = ci.inhrelid
+                    WHERE ci.inhparent = c.oid
+                )
+                ELSE c.reltuples::bigint
+            END AS row_estimate
         FROM pg_class c
         JOIN pg_namespace n ON n.oid = c.relnamespace
+        LEFT JOIN pg_inherits i ON i.inhrelid = c.oid AND c.relispartition
+        LEFT JOIN pg_class pc ON pc.oid = i.inhparent
+        LEFT JOIN pg_namespace pn ON pn.oid = pc.relnamespace
         WHERE n.nspname = ANY($1)
-          AND c.relkind = 'r'
+          AND c.relkind IN ('r', 'p')
         ORDER BY n.nspname, c.relname
         "#,
     )
@@ -163,6 +186,8 @@ pub async fn list_tables(pool: &PgPool, schemas: &[String]) -> anyhow::Result<Ve
         .iter()
         .map(|r| {
             let raw_estimate: i64 = r.get("row_estimate");
+            let parent_schema: Option<String> = r.get("parent_schema");
+            let parent_name: Option<String> = r.get("parent_name");
             TableInfo {
                 schema: r.get("schema_name"),
                 name: r.get("table_name"),
@@ -171,6 +196,10 @@ pub async fn list_tables(pool: &PgPool, schemas: &[String]) -> anyhow::Result<Ve
                 } else {
                     Some(raw_estimate)
                 },
+                is_partitioned: r.get("is_partitioned"),
+                partition_parent: parent_schema
+                    .zip(parent_name)
+                    .map(|(ps, pn)| format!("{ps}.{pn}")),
             }
         })
         .collect();


### PR DESCRIPTION
Closes #112

## Summary

- The table list query filtered on relkind = 'r'. That includes every partition child and excludes the partitioned parent. A partitioned database showed hundreds of partition rows and no parent row.
- list_tables now returns regular tables, partitioned parents (is_partitioned), and children tagged with partition_parent ("schema.name").
- A parent row carries a summed row estimate across its direct children.
- The sidebar groups partition children under their parent behind a chevron toggle. The parent shows a layers badge. The section header counts partitions separately.
- Selecting the parent queries merged data across all partitions. PostgreSQL merges natively when you select from the parent.
- Search matches partition names and auto-expands the matching parent.
- test_connection and list_schemas exclude partition children and count partitioned parents as tables.
- The display config skips partition children, so the bulk column fetch stays small.

## Test plan

- [x] cargo test: 250 passed
- [x] vitest: 171 passed
- [x] frontend build passes
- [ ] Manual check against the AutoConnect partitioned database