### PR TITLE
feat(sidebar): draggable width and schema prefixes as tags

### DIFF
--- a/frontend/src/components/Sidebar.svelte
+++ b/frontend/src/components/Sidebar.svelte
@@ -1,7 +1,13 @@
 <script lang="ts">
   import { type Snippet } from 'svelte';
   import { ChevronLeft, LayoutGrid, Settings } from 'lucide-svelte';
-  import { SIDEBAR_COLLAPSED_KEY } from '../lib/constants';
+  import {
+    SIDEBAR_COLLAPSED_KEY,
+    SIDEBAR_WIDTH_DEFAULT,
+    SIDEBAR_WIDTH_KEY,
+    SIDEBAR_WIDTH_MAX,
+    SIDEBAR_WIDTH_MIN,
+  } from '../lib/constants';
   import type { SidebarMode } from '../lib/types';
 
   let {
@@ -39,9 +45,64 @@
   function selectMode(nextMode: SidebarMode) {
     onSelectMode?.(nextMode);
   }
+
+  function clampWidth(value: number): number {
+    return Math.min(SIDEBAR_WIDTH_MAX, Math.max(SIDEBAR_WIDTH_MIN, value));
+  }
+
+  function readStoredWidth(): number {
+    const raw = Number(localStorage.getItem(SIDEBAR_WIDTH_KEY));
+    if (!Number.isFinite(raw) || raw <= 0) {
+      return SIDEBAR_WIDTH_DEFAULT;
+    }
+    return clampWidth(raw);
+  }
+
+  let width = $state(readStoredWidth());
+  let resizing = $state(false);
+
+  function startResize(event: PointerEvent) {
+    if (collapsed) return;
+    event.preventDefault();
+    resizing = true;
+    const startX = event.clientX;
+    const startWidth = width;
+
+    const onMove = (moveEvent: PointerEvent) => {
+      width = clampWidth(startWidth + moveEvent.clientX - startX);
+    };
+    const onUp = () => {
+      resizing = false;
+      localStorage.setItem(SIDEBAR_WIDTH_KEY, String(width));
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onUp);
+    };
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', onUp);
+  }
+
+  function handleResizeKeydown(event: KeyboardEvent) {
+    const step = event.shiftKey ? 32 : 8;
+    if (event.key === 'ArrowLeft' || event.key === 'ArrowRight') {
+      event.preventDefault();
+      width = clampWidth(width + (event.key === 'ArrowRight' ? step : -step));
+      localStorage.setItem(SIDEBAR_WIDTH_KEY, String(width));
+    }
+  }
+
+  function resetWidth() {
+    width = SIDEBAR_WIDTH_DEFAULT;
+    localStorage.setItem(SIDEBAR_WIDTH_KEY, String(width));
+  }
 </script>
 
-<aside class="sidebar" class:collapsed data-testid="app-sidebar">
+<aside
+  class="sidebar"
+  class:collapsed
+  class:resizing
+  style={collapsed ? '' : `width: ${width}px; min-width: ${width}px;`}
+  data-testid="app-sidebar"
+>
   <div class="header">
     {#if collapsed}
       <!-- collapsed: logo mark IS the expand button — no separate chevron -->
@@ -151,6 +212,21 @@
     <div class="footer">
       <span class="footer-text">Powered by SeeKi</span>
     </div>
+    <div
+      class="resize-handle"
+      role="separator"
+      aria-orientation="vertical"
+      aria-label="Resize sidebar"
+      aria-valuenow={width}
+      aria-valuemin={SIDEBAR_WIDTH_MIN}
+      aria-valuemax={SIDEBAR_WIDTH_MAX}
+      tabindex="0"
+      title="Drag to resize. Double-click to reset."
+      onpointerdown={startResize}
+      ondblclick={resetWidth}
+      onkeydown={handleResizeKeydown}
+      data-testid="sidebar-resize-handle"
+    ></div>
   {/if}
 </aside>
 
@@ -178,6 +254,38 @@
   .sidebar.collapsed {
     width: var(--sk-sidebar-collapsed);
     min-width: var(--sk-sidebar-collapsed);
+  }
+
+  /* while dragging, the width transition would lag behind the pointer */
+  .sidebar.resizing {
+    transition: none;
+    user-select: none;
+  }
+
+  /* ── Resize handle: invisible strip on the right edge, accent line on hover ── */
+  .resize-handle {
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 6px;
+    height: 100%;
+    cursor: col-resize;
+    z-index: 5;
+    touch-action: none;
+  }
+
+  .resize-handle:hover,
+  .sidebar.resizing .resize-handle {
+    background: linear-gradient(
+      to right,
+      transparent,
+      rgba(var(--marble-active-rgb), 0.35)
+    );
+  }
+
+  .resize-handle:focus-visible {
+    outline: 2px solid var(--sk-focus-ring);
+    outline-offset: -2px;
   }
 
   /* ── Header ── */

--- a/frontend/src/components/TableList.svelte
+++ b/frontend/src/components/TableList.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { Pencil, Search } from 'lucide-svelte';
+  import { Pencil, Search, Tags } from 'lucide-svelte';
+  import { SCHEMA_PREFIXES_KEY } from '../lib/constants';
   import type { TableInfo } from '../lib/types';
 
   const MAX_DISPLAY_NAME_LENGTH = 64;
@@ -42,6 +43,28 @@
     }
 
     return table.schema === 'public' ? table.name : `${table.schema}.${table.name}`;
+  }
+
+  // Schema prefixes collapse to tags by default. The full prefix mode stays
+  // available via the Tags toggle next to the search box.
+  let showSchemaPrefixes = $state(localStorage.getItem(SCHEMA_PREFIXES_KEY) === 'full');
+
+  function toggleSchemaPrefixes() {
+    showSchemaPrefixes = !showSchemaPrefixes;
+    localStorage.setItem(SCHEMA_PREFIXES_KEY, showSchemaPrefixes ? 'full' : 'tags');
+  }
+
+  function displayLabel(table: TableInfo): string {
+    return showSchemaPrefixes ? prettyLabel(table) : table.name;
+  }
+
+  // In tag mode the schema shows as a small tag. The tag stays hidden until
+  // the row is hovered, except on a name collision where it always shows.
+  function schemaTag(table: TableInfo): string | null {
+    if (showSchemaPrefixes || table.schema === 'public') {
+      return null;
+    }
+    return table.schema;
   }
 
   let search = $state('');
@@ -111,18 +134,32 @@
     </div>
   {/if}
 
-  <label class="panel-search table-search" data-testid="table-list-search">
-    <Search size={14} />
-    <input
-      bind:value={search}
-      class="panel-search-input table-search-input"
-      type="search"
-      placeholder="Search tables"
-      aria-label="Search tables"
-      spellcheck="false"
-      data-testid="table-search-input"
-    />
-  </label>
+  <div class="search-row">
+    <label class="panel-search table-search" data-testid="table-list-search">
+      <Search size={14} />
+      <input
+        bind:value={search}
+        class="panel-search-input table-search-input"
+        type="search"
+        placeholder="Search tables"
+        aria-label="Search tables"
+        spellcheck="false"
+        data-testid="table-search-input"
+      />
+    </label>
+    <button
+      type="button"
+      class="schema-toggle"
+      class:active={showSchemaPrefixes}
+      aria-label={showSchemaPrefixes ? 'Collapse schema prefixes to tags' : 'Show full schema prefixes'}
+      aria-pressed={showSchemaPrefixes}
+      title={showSchemaPrefixes ? 'Collapse schema prefixes to tags' : 'Show full schema prefixes'}
+      onclick={toggleSchemaPrefixes}
+      data-testid="schema-prefix-toggle"
+    >
+      <Tags size={14} />
+    </button>
+  </div>
 
   <div class="list-items" data-testid="table-list-items">
     {#if filteredTables.length > 0}
@@ -155,7 +192,12 @@
               title={`${table.schema}.${table.name}`}
               data-testid={`table-item-${tableKey(table)}`}
             >
-              <span class="table-item-name">{prettyLabel(table)}</span>
+              <span class="table-item-name">{displayLabel(table)}</span>
+              {#if schemaTag(table)}
+                <span class="schema-tag" class:always={collidingNames.has(table.name)}>
+                  {schemaTag(table)}
+                </span>
+              {/if}
               {#if table.row_count_estimate != null}
                 <span class="table-item-count">{table.row_count_estimate.toLocaleString()}</span>
               {/if}
@@ -211,6 +253,72 @@
     margin-top: var(--sk-space-xs);
     font-size: var(--sk-font-size-sm);
     color: var(--sk-muted);
+  }
+
+  .search-row {
+    display: flex;
+    align-items: center;
+    gap: var(--sk-space-xs);
+    padding-right: var(--sk-space-xs);
+  }
+
+  .search-row .panel-search {
+    flex: 1;
+    min-width: 0;
+  }
+
+  /* Tags toggle: switches between full schema prefixes and tag mode */
+  .schema-toggle {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    border: 1px solid var(--sk-border-light);
+    border-radius: var(--sk-radius-md);
+    background: none;
+    color: var(--sk-muted);
+    cursor: pointer;
+    transition: background 120ms ease, color 120ms ease;
+  }
+
+  .schema-toggle:hover {
+    background: var(--sk-active-tint-soft);
+    color: var(--sk-text);
+  }
+
+  .schema-toggle.active {
+    background: var(--sk-active-tint-soft);
+    color: var(--sk-ink-strong);
+  }
+
+  .schema-toggle:focus-visible {
+    outline: 2px solid var(--sk-focus-ring);
+    outline-offset: 2px;
+  }
+
+  /* schema tag: hidden until row hover, always shown on a name collision */
+  .schema-tag {
+    display: none;
+    flex-shrink: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: var(--sk-font-size-xs);
+    color: var(--sk-muted);
+    background: rgba(var(--marble-vein-rgb), 0.07);
+    border-radius: var(--sk-radius-pill);
+    padding: 1px 6px;
+    max-width: 45%;
+  }
+
+  .table-row:hover .schema-tag,
+  .table-row:focus-within .schema-tag,
+  .table-row.active .schema-tag,
+  .schema-tag.always {
+    display: inline-block;
   }
 
   /* search bar — padded to align with rows */

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -1,6 +1,17 @@
 /** localStorage key for sidebar collapsed state — used by App.svelte (read) and Sidebar.svelte (write). */
 export const SIDEBAR_COLLAPSED_KEY = 'sk-sidebar-collapsed';
 
+/** localStorage key for the user-resized sidebar width in pixels. */
+export const SIDEBAR_WIDTH_KEY = 'sk-sidebar-width';
+
+/** Sidebar width bounds and default, in pixels. The default matches --sk-sidebar-width. */
+export const SIDEBAR_WIDTH_DEFAULT = 236;
+export const SIDEBAR_WIDTH_MIN = 180;
+export const SIDEBAR_WIDTH_MAX = 480;
+
+/** localStorage key for the schema-prefix visibility toggle in the table list. */
+export const SCHEMA_PREFIXES_KEY = 'sk-schema-prefixes';
+
 /** localStorage key prefix for per-table column visibility state. */
 export const COLUMN_VISIBILITY_KEY_PREFIX = 'sk-column-visibility-';
 


### PR DESCRIPTION
Closes #113

## Summary

- A drag handle on the sidebar's right edge resizes it between 180px and 480px. The width persists in localStorage. Double-click resets to the 236px default. Arrow keys resize when the handle has keyboard focus.
- Schema prefixes collapse by default. Rows show the bare table name. The schema renders as a small muted tag that appears on hover, focus, the active row, and always when two tables share a name.
- A Tags toggle next to the search box switches back to full schema-qualified names. The choice persists in localStorage.
- Search matches the schema-qualified name in both modes. The full name stays in the row tooltip.

## Test plan

- [x] vitest: 171 passed
- [x] frontend build passes
- [ ] Manual check: drag, double-click reset, keyboard resize, tag visibility on hover and collision