### PR TITLE
fix(ci): resolve PR number from last ref in squash title

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -35,9 +35,14 @@ jobs:
                   if [ -n "${{ github.event.inputs.pr_number }}" ]; then
                     PR_NUM="${{ github.event.inputs.pr_number }}"
                   else
-                    # Parse "(#NN)" or "from <owner>/<branch>" from commit message
+                    # Parse the PR number from the squash commit title.
+                    # GitHub appends "(#PR)" at the END of the title, so take the
+                    # LAST "#NNN" match. An issue ref such as "(#112)" can appear
+                    # earlier in the title, and the body can carry more issue refs,
+                    # so only the first line is parsed.
                     MSG="${{ github.event.head_commit.message }}"
-                    PR_NUM=$(echo "$MSG" | grep -oE '#[0-9]+' | head -1 | tr -d '#')
+                    TITLE=$(echo "$MSG" | head -1)
+                    PR_NUM=$(echo "$TITLE" | grep -oE '#[0-9]+' | tail -1 | tr -d '#')
                   fi
 
                   if [ -z "$PR_NUM" ]; then


### PR DESCRIPTION
## Summary

Fixes #116.

The version-bump workflow took the first `#NNN` from the full commit message. A squash title such as `feat(sidebar): ... (#113) (#115)` carries the issue ref before the PR ref. The workflow resolved the issue number as a PR, `gh pr view` failed, and the bump skipped on both v26.7.2.0 merges.

## Change

In the "Resolve PR and source branch" step:
- Parse only the first line of the commit message. The body can carry more issue refs.
- Take the LAST `#NNN` match. GitHub appends `(#PR)` at the end of the squash title.
- The existing `gh pr view` failure path stays as the safety net.

## Test Plan

- [x] Dry run of the amended parse against both real failing titles:
  - `feat(tables): ... (#112) (#114)` → `114`
  - `feat(sidebar): ... (#113) (#115)` → `115`
  - a title with no refs → skip path
- [ ] Confirm the bump fires on the next real squash merge to main