### PR TITLE
fix(ci): pass commit message to version bump via env var

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -31,18 +31,22 @@ jobs:
               id: pr
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  # The message must reach bash as data, never as script text.
+                  # Inline ${{ }} interpolation lets a quote in a commit body
+                  # break the string and execute the rest as commands.
+                  COMMIT_MSG: ${{ github.event.head_commit.message }}
+                  INPUT_PR_NUMBER: ${{ github.event.inputs.pr_number }}
               run: |
-                  if [ -n "${{ github.event.inputs.pr_number }}" ]; then
-                    PR_NUM="${{ github.event.inputs.pr_number }}"
+                  if [ -n "$INPUT_PR_NUMBER" ]; then
+                    PR_NUM="$INPUT_PR_NUMBER"
                   else
                     # Parse the PR number from the squash commit title.
                     # GitHub appends "(#PR)" at the END of the title, so take the
                     # LAST "#NNN" match. An issue ref such as "(#112)" can appear
                     # earlier in the title, and the body can carry more issue refs,
                     # so only the first line is parsed.
-                    MSG="${{ github.event.head_commit.message }}"
-                    TITLE=$(echo "$MSG" | head -1)
-                    PR_NUM=$(echo "$TITLE" | grep -oE '#[0-9]+' | tail -1 | tr -d '#')
+                    TITLE=$(printf '%s\n' "$COMMIT_MSG" | head -1)
+                    PR_NUM=$(printf '%s\n' "$TITLE" | grep -oE '#[0-9]+' | tail -1 | tr -d '#')
                   fi
 
                   if [ -z "$PR_NUM" ]; then


### PR DESCRIPTION
## Summary

Fixes #135.

The resolve step interpolated the raw commit message into the shell script. A double quote in a squash commit body closed the string and bash executed the remainder as commands. Five epic bump runs failed this way, and the pattern is also a script injection vector.

## Change

The step now receives the message through the COMMIT_MSG environment variable and reads it with printf. The workflow_dispatch pr_number input moved to an env var for the same reason.

## Test Plan

- [x] YAML lint passes
- [ ] Bump fires on the next squash merge whose body contains a double quote