### PR TITLE
fix(ci): resolve clippy 1.97 lints and rustfmt drift

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -40,10 +40,7 @@ pub fn router(mode: SharedAppMode, store: Store) -> Router {
             "/tables/{schema}/{table}/relationships",
             get(get_relationships),
         )
-        .route(
-            "/tables/{schema}/{table}/references",
-            get(get_references),
-        )
+        .route("/tables/{schema}/{table}/references", get(get_references))
         .route("/tables/{schema}/{table}/samples", get(get_column_samples))
         .route("/tables/{schema}/{table}/rows", get(get_rows))
         .route("/tables/{schema}/{table}/row", get(get_single_row))
@@ -430,7 +427,12 @@ async fn get_relationships(
         .collect();
     let incoming: Vec<serde_json::Value> = incoming
         .iter()
-        .filter(|edge| state.config.tables.allows(&edge.other_schema, &edge.other_table))
+        .filter(|edge| {
+            state
+                .config
+                .tables
+                .allows(&edge.other_schema, &edge.other_table)
+        })
         .map(|edge| {
             serde_json::json!({
                 "constraint": edge.constraint_name,
@@ -546,7 +548,7 @@ async fn get_references(
         .await;
 
     let mut references: Vec<serde_json::Value> = Vec::with_capacity(candidates.len());
-    for ((edge, _), result) in candidates.iter().zip(counts.into_iter()) {
+    for ((edge, _), result) in candidates.iter().zip(counts) {
         let (count, capped) = result.map_err(|e| map_table_query_error(e, &edge.other_table))?;
         references.push(serde_json::json!({
             "schema": edge.other_schema,
@@ -648,7 +650,10 @@ fn parse_filters(all_params: &HashMap<String, String>) -> HashMap<String, String
 fn parse_exact_filters(all_params: &HashMap<String, String>) -> HashMap<String, String> {
     all_params
         .iter()
-        .filter_map(|(k, v)| k.strip_prefix("eq.").map(|col| (col.to_string(), v.clone())))
+        .filter_map(|(k, v)| {
+            k.strip_prefix("eq.")
+                .map(|col| (col.to_string(), v.clone()))
+        })
         .collect()
 }
 
@@ -819,9 +824,7 @@ async fn get_single_row(
     // no column metadata, so paying for it first wastes a database call.
     let exact_filters = parse_exact_filters(&all_params);
     if exact_filters.is_empty() {
-        return Err(AppError::bad_request(
-            "At least one eq. filter is required",
-        ));
+        return Err(AppError::bad_request("At least one eq. filter is required"));
     }
 
     let columns = load_table_columns(&state, &schema, &table).await?;

--- a/src/api/update.rs
+++ b/src/api/update.rs
@@ -339,7 +339,7 @@ pub async fn apply_update(
 
             // Require the SHA256 sidecar to be present in the release manifest
             // before downloading anything — fail fast if the release is incomplete.
-            let sha256_asset_name = format!("{}.sha256", &asset.name);
+            let sha256_asset_name = format!("{}.sha256", asset.name);
             let sha256_asset = release
                 .assets
                 .iter()

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -11,8 +11,8 @@ use tokio::sync::RwLock;
 use super::{
     ColumnInfo, ExportQueryParams, FkHop, QueryResult, RelationshipEdge, RowQueryParams,
     SavedViewAggregate, SavedViewColumn, SavedViewColumnKind, SavedViewSortDirection,
-    SortDirection, SortEntry, TableInfo, ValidationError, ViewAggregate, ViewColumn,
-    ViewColumnRef, ViewDefinitionShape, ViewDerivedColumn, ViewDerivedInput, ViewDerivedInputKind,
+    SortDirection, SortEntry, TableInfo, ValidationError, ViewAggregate, ViewColumn, ViewColumnRef,
+    ViewDefinitionShape, ViewDerivedColumn, ViewDerivedInput, ViewDerivedInputKind,
     ViewDerivedOperation, ViewDraft, ViewExportQueryParams, ViewFilterValue, ViewOrderBy,
     ViewRowsQueryParams, ViewSelfDirection, ViewSourceKind,
 };
@@ -893,7 +893,9 @@ fn reachable_tables_bfs(edges: &[FkEdge], base: &TableKey) -> Vec<(TableKey, u32
         }
     }
 
-    result.sort_by(|(a_key, a_hops), (b_key, b_hops)| a_hops.cmp(b_hops).then_with(|| a_key.cmp(b_key)));
+    result.sort_by(|(a_key, a_hops), (b_key, b_hops)| {
+        a_hops.cmp(b_hops).then_with(|| a_key.cmp(b_key))
+    });
     result
 }
 
@@ -1492,7 +1494,10 @@ pub async fn table_relationships(
         anyhow::bail!("Invalid table name: {table}");
     }
     let edges = get_fk_edges_cached(pool, schema).await?;
-    Ok(build_table_relationships(&edges, &TableKey::new(schema, table)))
+    Ok(build_table_relationships(
+        &edges,
+        &TableKey::new(schema, table),
+    ))
 }
 
 pub async fn lookup_fk_path(
@@ -1521,7 +1526,11 @@ pub async fn lookup_fk_path(
 /// Cap a raw row count at 1000 and report whether the true count exceeds it.
 /// The UI shows "1000+" instead of an unbounded number for a heavily referenced row.
 fn cap_count(count: i64) -> (i64, bool) {
-    if count > 1000 { (1000, true) } else { (count, false) }
+    if count > 1000 {
+        (1000, true)
+    } else {
+        (count, false)
+    }
 }
 
 /// Count rows in the source table of one incoming FK edge whose FK columns equal
@@ -4275,12 +4284,8 @@ mod tests {
         assert_eq!(cond, "\"price\" = $1::numeric");
         assert_eq!(bind.as_deref(), Some("19.99"));
 
-        let (cond, bind) = exact_filter_condition(
-            "token",
-            "uuid",
-            "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
-            1,
-        );
+        let (cond, bind) =
+            exact_filter_condition("token", "uuid", "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11", 1);
         assert_eq!(cond, "\"token\" = $1::uuid");
         assert!(bind.is_some());
 
@@ -4294,10 +4299,22 @@ mod tests {
 
     #[test]
     fn exact_filter_condition_collapses_malformed_values_to_false() {
-        assert_eq!(exact_filter_condition("id", "bigint", "42abc", 1).0, "FALSE");
-        assert_eq!(exact_filter_condition("price", "numeric", "cheap", 1).0, "FALSE");
-        assert_eq!(exact_filter_condition("token", "uuid", "not-a-uuid", 1).0, "FALSE");
-        assert_eq!(exact_filter_condition("ok", "boolean", "maybe", 1).0, "FALSE");
+        assert_eq!(
+            exact_filter_condition("id", "bigint", "42abc", 1).0,
+            "FALSE"
+        );
+        assert_eq!(
+            exact_filter_condition("price", "numeric", "cheap", 1).0,
+            "FALSE"
+        );
+        assert_eq!(
+            exact_filter_condition("token", "uuid", "not-a-uuid", 1).0,
+            "FALSE"
+        );
+        assert_eq!(
+            exact_filter_condition("ok", "boolean", "maybe", 1).0,
+            "FALSE"
+        );
     }
 
     #[test]
@@ -4387,8 +4404,8 @@ mod tests {
         exact.insert("vehicle_id".to_string(), "ADT3".to_string());
         exact.insert("is_active".to_string(), "yes".to_string());
 
-        let qb = build_query_clauses(&columns, None, &HashMap::new(), &exact, &[], false, 1)
-            .unwrap();
+        let qb =
+            build_query_clauses(&columns, None, &HashMap::new(), &exact, &[], false, 1).unwrap();
 
         // Sorted by column name: id, is_active, vehicle_id.
         assert_eq!(
@@ -4901,13 +4918,7 @@ mod tests {
                 &["id"],
                 "orders_apple_fkey",
             ),
-            fk_edge(
-                "apples",
-                "trees",
-                &["tree_id"],
-                &["id"],
-                "apples_tree_fkey",
-            ),
+            fk_edge("apples", "trees", &["tree_id"], &["id"], "apples_tree_fkey"),
         ];
 
         let reachable = reachable_tables_bfs(&edges, &TableKey::new("public", "orders"));


### PR DESCRIPTION
## Summary

Fixes #138. Restores a green CI on main before the release cut.

## Change

- src/api/update.rs: remove a redundant reference in a format argument.
- src/api/mod.rs: drop a useless into_iter call in the references handler.
- cargo fmt over the files the epic merge left drifted.

## Test Plan

- [x] cargo test: 282 passed
- [x] cargo clippy --all-targets: clean
- [x] cargo fmt --check: clean