### PR TITLE
fix(timezone): resolve one display timezone across grid, export, and SQL date math

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ tower-http = { version = "0.6", features = ["fs", "cors"] }
 sqlx = { version = "0.8", features = ["runtime-tokio", "tls-rustls", "postgres", "sqlite", "chrono", "uuid", "rust_decimal", "ipnet"] }
 rust_decimal = { version = "1", features = ["serde-str"] }
 chrono = { version = "0.4", features = ["serde"] }
+chrono-tz = "0.10"
 uuid = { version = "1", features = ["serde"] }
 
 # Serialization

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -35,6 +35,7 @@
     updateTableDisplayName,
   } from './lib/api';
   import type { FetchRowsParams } from './lib/api';
+  import { setDisplayTimeZone } from './lib/data-grid';
   import type {
     AppearanceSettings,
     BrandingSettings,
@@ -372,6 +373,9 @@
         tables = fetchedTables;
         savedViews = views;
         displayConfig = config;
+        // Pin the render zone before any grid formatting runs, so cells never
+        // flash in the viewer's local zone and then shift.
+        setDisplayTimeZone(config.timezone);
         appSettings = settings;
         const dataSettings = parseDataSettings(settings);
         pageSize = dataSettings.pageSize;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -261,7 +261,7 @@ export async function fetchRows(
 export async function fetchDisplayConfig(): Promise<DisplayConfig> {
   if (USE_MOCK) return mockFetchDisplayConfig();
   const data = await apiFetch<DisplayConfig>('/api/config/display');
-  assertShape(data, ['branding', 'tables'], '/api/config/display');
+  assertShape(data, ['branding', 'tables', 'timezone'], '/api/config/display');
   return data;
 }
 

--- a/frontend/src/lib/data-grid.test.ts
+++ b/frontend/src/lib/data-grid.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import {
   formatCellValue,
   columnWidth,
@@ -7,6 +7,8 @@ import {
   sortStateToConfig,
   getColumnDisplayName,
   buildSortableColumn,
+  setDisplayTimeZone,
+  getDisplayTimeZone,
 } from './data-grid';
 import type { ColumnInfo } from './types';
 
@@ -151,6 +153,86 @@ describe('formatCellValue', () => {
       const customCol = col({ data_type: 'text', display_type: 'datetime' });
       const result = formatCellValue(customCol, '2024-01-15T14:30:00');
       expect(result.kind).toBe('timestamp');
+    });
+  });
+
+  describe('display timezone', () => {
+    const tzCol = col({ data_type: 'timestamp with time zone' });
+    const naiveCol = col({ data_type: 'timestamp without time zone' });
+
+    // The 'YYYY-MM-DD' branch renders "<date> <time>" where <time> still comes
+    // from Intl with the ambient locale (so it may be "14:30" or "2:30 PM").
+    // Build the expectation the same way to assert on the zone arithmetic
+    // without pinning the test machine's locale.
+    function expected(date: string, hour: number, minute: number): string {
+      const time = new Intl.DateTimeFormat(undefined, {
+        hour: 'numeric',
+        minute: '2-digit',
+      }).format(new Date(2024, 0, 15, hour, minute));
+      return `${date} ${time}`;
+    }
+
+    afterEach(() => {
+      setDisplayTimeZone(undefined);
+    });
+
+    it('renders timestamptz in the configured zone, not the browser zone', () => {
+      setDisplayTimeZone('Asia/Singapore');
+      // 06:30Z is 14:30 +08. The grid must agree with the offset the backend
+      // serialized rather than with wherever the viewer happens to be.
+      const result = formatCellValue(tzCol, '2024-01-15T06:30:00Z', 'YYYY-MM-DD');
+      expect(result.display).toBe(expected('2024-01-15', 14, 30));
+    });
+
+    it('keeps the calendar date of the configured zone across a day boundary', () => {
+      setDisplayTimeZone('Asia/Singapore');
+      // 23:00Z on the 15th is 07:00 +08 on the 16th. Reading parts off the Date
+      // in the browser's zone would name the wrong day here.
+      const result = formatCellValue(tzCol, '2024-01-15T23:00:00Z', 'YYYY-MM-DD');
+      expect(result.display).toBe(expected('2024-01-16', 7, 0));
+    });
+
+    it('shows offset-less timestamps verbatim rather than shifting them', () => {
+      setDisplayTimeZone('Asia/Singapore');
+      // A naive value is already wall-clock in the display zone, so it must not
+      // be converted — 14:30 stays 14:30 whatever the browser zone is.
+      const result = formatCellValue(naiveCol, '2024-01-15 14:30:00', 'YYYY-MM-DD');
+      expect(result.display).toBe(expected('2024-01-15', 14, 30));
+    });
+
+    it('respects an explicit +08:00 offset on the wire value', () => {
+      setDisplayTimeZone('Asia/Singapore');
+      const result = formatCellValue(tzCol, '2024-01-15T14:30:00+08:00', 'YYYY-MM-DD');
+      expect(result.display).toBe(expected('2024-01-15', 14, 30));
+    });
+
+    it('preserves the raw wire value in the tooltip', () => {
+      setDisplayTimeZone('Asia/Singapore');
+      const raw = '2024-01-15T14:30:00+08:00';
+      expect(formatCellValue(tzCol, raw).tooltip).toBe(raw);
+    });
+
+    it('does not read a bare date\'s day as an offset', () => {
+      setDisplayTimeZone('Asia/Singapore');
+      // "2024-01-15" has no time component; treating the trailing "-15" as a
+      // -15:00 offset would shift the rendered day.
+      const result = formatCellValue(naiveCol, '2024-01-15', 'YYYY-MM-DD');
+      expect(result.display).toContain('2024-01-15');
+    });
+
+    it('ignores an unrecognised zone instead of throwing', () => {
+      setDisplayTimeZone('Mars/Olympus');
+      expect(getDisplayTimeZone()).toBeUndefined();
+      expect(formatCellValue(tzCol, '2024-01-15T06:30:00Z').kind).toBe('timestamp');
+    });
+
+    it('applies a changed zone to subsequent formatting', () => {
+      setDisplayTimeZone('Asia/Singapore');
+      const sgt = formatCellValue(tzCol, '2024-01-15T06:30:00Z', 'YYYY-MM-DD');
+      setDisplayTimeZone('UTC');
+      const utc = formatCellValue(tzCol, '2024-01-15T06:30:00Z', 'YYYY-MM-DD');
+      expect(sgt.display).toBe(expected('2024-01-15', 14, 30));
+      expect(utc.display).toBe(expected('2024-01-15', 6, 30));
     });
   });
 

--- a/frontend/src/lib/data-grid.ts
+++ b/frontend/src/lib/data-grid.ts
@@ -32,13 +32,55 @@ const DATETIME_TYPES = new Set([
   'timestamp with time zone',
 ]);
 
-const dateFormatter = new Intl.DateTimeFormat(undefined, {
-  year: 'numeric',
-  month: 'short',
-  day: 'numeric',
-});
+// The zone every timestamp renders in, set once from /api/config/display so the
+// grid, the tooltip, the CSV export and SQL-side date buckets all agree. Until
+// it arrives, `undefined` keeps Intl on the viewer's local zone — the previous
+// behaviour, and the only sensible guess before the backend has told us.
+let displayTimeZone: string | undefined;
 
-const formatter = new Intl.DateTimeFormat(undefined, {
+// Intl.DateTimeFormat construction is not free and these are hit per cell, so
+// they are cached and only rebuilt when the configured zone changes.
+let dateFormatter: Intl.DateTimeFormat;
+let formatter: Intl.DateTimeFormat;
+let timeFormatter: Intl.DateTimeFormat;
+let partsFormatter: Intl.DateTimeFormat;
+
+function buildFormatters(timeZone: string | undefined): void {
+  dateFormatter = new Intl.DateTimeFormat(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    timeZone,
+  });
+  formatter = new Intl.DateTimeFormat(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    timeZone,
+  });
+  timeFormatter = new Intl.DateTimeFormat(undefined, {
+    hour: 'numeric',
+    minute: '2-digit',
+    timeZone,
+  });
+  // Explicit-format branches need the calendar date *in the display zone*, not
+  // the browser's — date.getFullYear() would silently reintroduce local time.
+  partsFormatter = new Intl.DateTimeFormat('en-CA', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    timeZone,
+  });
+}
+
+buildFormatters(undefined);
+
+// Deliberately zone-less and never rebuilt: offset-less `timestamp` values are
+// rendered from a Date whose *local* parts hold the literal wall-clock, so
+// applying any timeZone here would shift them back off again.
+const naiveFormatter = new Intl.DateTimeFormat(undefined, {
   year: 'numeric',
   month: 'short',
   day: 'numeric',
@@ -46,10 +88,32 @@ const formatter = new Intl.DateTimeFormat(undefined, {
   minute: '2-digit',
 });
 
-const timeFormatter = new Intl.DateTimeFormat(undefined, {
+const naiveTimeFormatter = new Intl.DateTimeFormat(undefined, {
   hour: 'numeric',
   minute: '2-digit',
 });
+
+/**
+ * Pin the zone used to render every timestamp. Called once with the value from
+ * /api/config/display. An unrecognised zone is ignored rather than thrown, so a
+ * bad config degrades to local time instead of blanking the grid.
+ */
+export function setDisplayTimeZone(timeZone: string | undefined): void {
+  if (timeZone === displayTimeZone) return;
+  try {
+    new Intl.DateTimeFormat(undefined, { timeZone }).format(new Date());
+  } catch {
+    console.warn(`Ignoring unrecognised display timezone: ${timeZone}`);
+    return;
+  }
+  displayTimeZone = timeZone;
+  buildFormatters(timeZone);
+}
+
+/** The zone currently used for rendering, or undefined for the viewer's local zone. */
+export function getDisplayTimeZone(): string | undefined {
+  return displayTimeZone;
+}
 
 export interface FormattedCellValue {
   kind: 'null' | 'boolean' | 'number' | 'timestamp' | 'text';
@@ -175,15 +239,24 @@ export function formatCellValue(
   ) {
     const raw = String(value);
     // Replace space with T for ISO 8601 compliance — Safari rejects "2024-01-15 14:30:00"
-    const parsed = new Date(raw.replace(' ', 'T'));
-
-    if (!Number.isNaN(parsed.getTime())) {
-      return {
-        kind: 'timestamp',
-        display: formatDateTime(parsed, dateFormat),
-        tooltip: raw,
-      };
+    const isoish = raw.replace(' ', 'T');
+    // A `timestamptz` arrives with an explicit offset and is a real instant, so
+    // it renders in the configured display zone. A naive `timestamp` has no
+    // offset and is already wall-clock in that zone — reformatting it through
+    // Intl would shift it by the browser-vs-display zone difference, so its
+    // parts are shown verbatim.
+    const parsed = new Date(isoish);
+    if (Number.isNaN(parsed.getTime())) {
+      return { kind: 'text', display: raw };
     }
+
+    return {
+      kind: 'timestamp',
+      display: hasExplicitOffset(isoish)
+        ? formatDateTime(parsed, dateFormat)
+        : formatNaiveDateTime(isoish, dateFormat),
+      tooltip: raw,
+    };
   }
 
   if (NUMERIC_TEXT_TYPES.has(column.data_type)) {
@@ -229,9 +302,10 @@ function formatDate(date: Date, dateFormat: DateFormatPreference): string {
     return dateFormatter.format(date);
   }
 
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
+  // en-CA yields "YYYY-MM-DD", giving the calendar parts as seen in the display
+  // zone. Reading them off the Date directly would use the browser's zone and
+  // could name a different day than the 'system' branch above.
+  const [year, month, day] = partsFormatter.format(date).split('-');
 
   switch (dateFormat) {
     case 'YYYY-MM-DD':
@@ -251,6 +325,58 @@ function formatDateTime(date: Date, dateFormat: DateFormatPreference): string {
   }
 
   return `${formatDate(date, dateFormat)} ${timeFormatter.format(date)}`;
+}
+
+/** Matches a trailing `Z`, `+HH:MM`, `-HH:MM`, `+HHMM` or `+HH` on the time part. */
+const EXPLICIT_OFFSET = /(?:Z|[+-]\d{2}(?::?\d{2})?)$/;
+
+function hasExplicitOffset(isoish: string): boolean {
+  const separator = isoish.indexOf('T');
+  // No time component at all means no offset. Scanning the whole string here
+  // would read the "-15" of "2024-01-15" as a -15:00 offset.
+  if (separator === -1) return false;
+  return EXPLICIT_OFFSET.test(isoish.slice(separator + 1));
+}
+
+/**
+ * Render an offset-less `timestamp` using its own literal parts.
+ *
+ * These values are wall-clock in the configured display zone already, so they
+ * are reassembled rather than pushed through Intl — which would interpret them
+ * as browser-local and shift them.
+ */
+function formatNaiveDateTime(
+  isoish: string,
+  dateFormat: DateFormatPreference,
+): string {
+  const [datePart, timePart = ''] = isoish.split('T');
+  const [year, month, day] = datePart.split('-');
+  const [hour = '00', minute = '00'] = timePart.split(':');
+  if (!year || !month || !day) return isoish;
+
+  // Reuse the shared formatters by handing them a Date whose *local* parts equal
+  // the literal ones, so 'system' output stays locale-shaped (e.g. "30 Jul 2026,
+  // 2:30 pm") without any zone conversion applied.
+  const asLocal = new Date(
+    Number(year),
+    Number(month) - 1,
+    Number(day),
+    Number(hour),
+    Number(minute),
+  );
+  if (Number.isNaN(asLocal.getTime())) return isoish;
+
+  if (dateFormat === 'system') {
+    return naiveFormatter.format(asLocal);
+  }
+
+  const date =
+    dateFormat === 'YYYY-MM-DD'
+      ? `${year}-${month}-${day}`
+      : dateFormat === 'DD/MM/YYYY'
+        ? `${day}/${month}/${year}`
+        : `${month}/${day}/${year}`;
+  return `${date} ${naiveTimeFormatter.format(asLocal)}`;
 }
 
 export function buildSortableColumn(

--- a/frontend/src/lib/mock.ts
+++ b/frontend/src/lib/mock.ts
@@ -555,6 +555,9 @@ export function mockFetchDisplayConfig(): DisplayConfig {
       title: 'SeeKi',
       subtitle: 'Database Viewer',
     },
+    // A non-UTC zone so mock mode exercises the offset path rather than the
+    // case where local, UTC and display zones happen to coincide.
+    timezone: 'Asia/Singapore',
     tables: Object.fromEntries(
       TABLES.map((t) => [
         `${t.schema}.${t.name}`,

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -226,6 +226,10 @@ export interface DisplayConfig {
     title: string | null;
     subtitle: string | null;
   };
+  // IANA zone all timestamps are rendered in, matching the offset the backend
+  // serialized and the zone SQL-side date bucketing used. Formatting in the
+  // viewer's own zone instead made the same row read differently per user.
+  timezone: string;
   // Keyed by qualified "schema.table" (including "public.table").
   tables: Record<
     string,

--- a/seeki.toml.example
+++ b/seeki.toml.example
@@ -16,6 +16,20 @@ max_connections = 5
 include = ["vehicles_log", "drivers", "audit_log"]
 exclude = ["audit_log"]
 
+# Timezone every timestamp is interpreted and rendered in — an IANA name.
+# Defaults to "UTC" when omitted.
+#
+# This is one setting rather than a display-only preference because SQL-side
+# date math has to agree with what the grid shows: day/week bucketing in custom
+# views, weekday and year/month grouping, "age of timestamp", and date filters
+# are all evaluated in this zone. Set it to where your data was recorded, or a
+# row can render in one day and be counted in another.
+#
+# Changing it changes the output of existing saved views that bucket by
+# day/week. Must appear before the [display.*] subtables below.
+[display]
+timezone = "Asia/Singapore"
+
 # Optional sidebar display name overrides for tables.
 [display.tables]
 vehicles_log = "Fleet Log"

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -79,6 +79,10 @@ async fn require_state(mode: &SharedAppMode) -> Result<Arc<AppState>, AppError> 
 struct DisplayConfigResponse {
     branding: BrandingResponse,
     tables: HashMap<String, TableDisplayConfig>,
+    /// IANA name the frontend must format timestamps in, so the grid agrees with
+    /// the offset the backend serialized and with SQL-side date bucketing.
+    /// Without this the browser rendered in the viewer's own zone.
+    timezone: String,
 }
 
 #[derive(Serialize)]
@@ -177,6 +181,7 @@ async fn get_display_config(
             &settings,
         ),
         tables,
+        timezone: crate::db::timezone::display_timezone().name().to_string(),
     }))
 }
 
@@ -790,17 +795,25 @@ fn pg_value_to_csv_string(row: &sqlx::postgres::PgRow, col: &str, data_type: &st
             .try_get::<chrono::NaiveDateTime, _>(col)
             .map(|v| v.format("%Y-%m-%d %H:%M:%S").to_string())
             .unwrap_or_default(),
+        // Same zone the grid renders in — exporting UTC while showing local time
+        // meant the file disagreed with the screen it came from.
         "timestamp with time zone" => row
             .try_get::<chrono::DateTime<chrono::Utc>, _>(col)
-            .map(|v| v.to_rfc3339())
+            .map(|v| {
+                crate::db::timezone::format_timestamptz(v, crate::db::timezone::display_timezone())
+            })
             .unwrap_or_default(),
         "date" => row
             .try_get::<chrono::NaiveDate, _>(col)
             .map(|v| v.format("%Y-%m-%d").to_string())
             .unwrap_or_default(),
-        "time without time zone" | "time with time zone" => row
+        "time without time zone" => row
             .try_get::<chrono::NaiveTime, _>(col)
             .map(|v| v.format("%H:%M:%S").to_string())
+            .unwrap_or_default(),
+        "time with time zone" => row
+            .try_get::<crate::db::postgres::PgTimeTzChrono, _>(col)
+            .map(crate::db::postgres::format_timetz)
             .unwrap_or_default(),
         "uuid" => row
             .try_get::<uuid::Uuid, _>(col)
@@ -982,12 +995,14 @@ mod tests {
                 subtitle: Some("Fleet Telemetry".into()),
             },
             tables: HashMap::new(),
+            timezone: "Asia/Singapore".into(),
         };
 
         let json = serde_json::to_value(&response).unwrap();
         assert_eq!(json["branding"]["title"], "My Database");
         assert_eq!(json["branding"]["subtitle"], "Fleet Telemetry");
         assert!(json["tables"].as_object().unwrap().is_empty());
+        assert_eq!(json["timezone"], "Asia/Singapore");
     }
 
     #[test]
@@ -998,6 +1013,7 @@ mod tests {
                 subtitle: None,
             },
             tables: HashMap::new(),
+            timezone: "UTC".into(),
         };
 
         let json = serde_json::to_value(&response).unwrap();
@@ -1391,6 +1407,7 @@ mod tests {
         let config = DisplayConfig {
             tables: HashMap::new(),
             columns: columns_map,
+            ..DisplayConfig::default()
         };
 
         let sibling_names: Vec<&str> = columns.iter().map(|c| c.name.as_str()).collect();
@@ -1434,6 +1451,7 @@ mod tests {
         let config = DisplayConfig {
             tables,
             columns: HashMap::new(),
+            ..DisplayConfig::default()
         };
 
         let display = display_name_table("public", "vehicles_log", &config)

--- a/src/api/setup.rs
+++ b/src/api/setup.rs
@@ -359,7 +359,23 @@ pub async fn save_config(
     };
 
     let ssh_ref = app_config.ssh.as_ref().map(|s| (s, &secrets));
-    let db = match DatabasePool::connect(&app_config.database, ssh_ref).await {
+    // Validated by the parse above, so this is infallible in practice.
+    let requested_tz = app_config
+        .display
+        .resolved_timezone()
+        .unwrap_or(chrono_tz::Tz::UTC);
+    let display_tz = crate::db::timezone::set_display_timezone(requested_tz);
+    if display_tz != requested_tz {
+        // The zone is installed process-wide once. A second setup pass in the
+        // same process keeps the original, so flag the mismatch instead of
+        // rendering timestamps in a zone the new config does not name.
+        tracing::warn!(
+            requested = %requested_tz.name(),
+            in_effect = %display_tz.name(),
+            "display timezone already fixed for this process — restart to apply the new value"
+        );
+    }
+    let db = match DatabasePool::connect(&app_config.database, ssh_ref, display_tz).await {
         Ok(d) => d,
         Err(e) => {
             let _ = std::fs::remove_file("seeki.toml");

--- a/src/config.rs
+++ b/src/config.rs
@@ -105,6 +105,26 @@ pub struct DisplayConfig {
     pub tables: HashMap<String, String>,
     #[serde(default)]
     pub columns: HashMap<String, HashMap<String, String>>,
+    /// IANA timezone every timestamp is interpreted and rendered in — the
+    /// Postgres session zone, the serialized offset, and the frontend's
+    /// formatting all follow it. Absent ⇒ UTC.
+    ///
+    /// This is deliberately one setting rather than a display-only preference:
+    /// SQL-side date math (`DATE_TRUNC` day/week buckets, `EXTRACT`, `AGE`, and
+    /// text→`timestamptz` filter casts) has to agree with what the grid shows,
+    /// or a row renders in one day and buckets into another.
+    #[serde(default)]
+    pub timezone: Option<String>,
+}
+
+impl DisplayConfig {
+    /// Resolve the configured timezone, defaulting to UTC when unset.
+    pub fn resolved_timezone(&self) -> anyhow::Result<chrono_tz::Tz> {
+        match &self.timezone {
+            Some(name) => crate::db::timezone::parse(name),
+            None => Ok(chrono_tz::Tz::UTC),
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -349,6 +369,12 @@ impl AppConfig {
                 "database.schemas must not be empty — remove the key to default to [\"public\"]"
             );
         }
+        // Reject a bad timezone at load rather than falling back to UTC — a
+        // silent fallback would shift every timestamp and every date bucket
+        // without the operator noticing the typo.
+        self.display
+            .resolved_timezone()
+            .map_err(|e| anyhow::anyhow!("display.timezone is invalid: {e}"))?;
         Ok(())
     }
 
@@ -754,6 +780,7 @@ subtitle = "Fleet Telemetry"
         let config = DisplayConfig {
             tables,
             columns: std::collections::HashMap::new(),
+            ..DisplayConfig::default()
         };
 
         // Qualified key matches.
@@ -786,6 +813,12 @@ subtitle = "Fleet Telemetry"
                 .and_then(|c| c.get("posn_lat"))
                 .map(String::as_str),
             Some("Latitude")
+        );
+        // The documented [display] section must sit before the [display.*]
+        // subtables or TOML rejects it — this asserts the example stays valid.
+        assert_eq!(
+            config.display.timezone.as_deref(),
+            Some("Asia/Singapore")
         );
     }
 
@@ -1038,6 +1071,76 @@ schemas = []
             err.to_string().contains("schemas must not be empty"),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn timezone_absent_defaults_to_utc() {
+        let config = AppConfig::parse(MINIMAL_CONFIG).expect("minimal should parse");
+        assert!(config.display.timezone.is_none());
+        assert_eq!(
+            config
+                .display
+                .resolved_timezone()
+                .expect("default should resolve"),
+            chrono_tz::Tz::UTC
+        );
+    }
+
+    #[test]
+    fn timezone_resolves_iana_name() {
+        let toml = r#"
+[server]
+host = "127.0.0.1"
+port = 3141
+[database]
+url = "postgres://u:p@localhost/db"
+[display]
+timezone = "Asia/Singapore"
+"#;
+        let config = AppConfig::parse(toml).expect("should parse");
+        assert_eq!(
+            config
+                .display
+                .resolved_timezone()
+                .expect("should resolve"),
+            chrono_tz::Tz::Asia__Singapore
+        );
+    }
+
+    #[test]
+    fn invalid_timezone_rejected_at_load() {
+        // A silent UTC fallback would shift every timestamp and every date
+        // bucket without the operator noticing the typo.
+        let toml = r#"
+[server]
+host = "127.0.0.1"
+port = 3141
+[database]
+url = "postgres://u:p@localhost/db"
+[display]
+timezone = "Asia/Singapor"
+"#;
+        let err = AppConfig::parse(toml).expect_err("typo must be rejected");
+        assert!(
+            err.to_string().contains("display.timezone is invalid"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn offset_shorthand_timezone_rejected() {
+        // "+08:00" carries no DST rules — accepting it would silently break
+        // zones that have them.
+        let toml = r#"
+[server]
+host = "127.0.0.1"
+port = 3141
+[database]
+url = "postgres://u:p@localhost/db"
+[display]
+timezone = "+08:00"
+"#;
+        AppConfig::parse(toml).expect_err("offset shorthand must be rejected");
     }
 
     #[test]

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,4 +1,5 @@
 pub mod postgres;
+pub mod timezone;
 
 use std::collections::HashMap;
 
@@ -527,9 +528,15 @@ pub enum DatabasePool {
 }
 
 impl DatabasePool {
+    /// `display_tz` pins each connection's session timezone so every SQL-side
+    /// date operation — `DATE_TRUNC` buckets, `EXTRACT`, `AGE`, and text→
+    /// `timestamptz` filter casts — is evaluated in the same zone the grid
+    /// renders in. Without it these inherited the server's `TimeZone` GUC, so
+    /// the same saved view produced different day buckets on different servers.
     pub async fn connect(
         config: &DatabaseConfig,
         ssh: Option<(&crate::config::SshConfig, &crate::config::SecretsConfig)>,
+        display_tz: chrono_tz::Tz,
     ) -> anyhow::Result<Self> {
         match config.kind {
             DatabaseKind::Postgres => {
@@ -559,8 +566,21 @@ impl DatabasePool {
                     (config.url.clone(), None)
                 };
 
+                // after_connect (not a one-off SET) so pool growth and
+                // reconnects land on the same zone as the first connection.
+                let tz_name = display_tz.name().to_string();
                 let pool = sqlx::postgres::PgPoolOptions::new()
                     .max_connections(config.max_connections)
+                    .after_connect(move |conn, _meta| {
+                        let tz_name = tz_name.clone();
+                        Box::pin(async move {
+                            sqlx::query(timezone::session_timezone_sql())
+                                .bind(tz_name)
+                                .execute(&mut *conn)
+                                .await?;
+                            Ok(())
+                        })
+                    })
                     .connect(&connect_url)
                     .await?;
                 Ok(Self::Postgres(pool, tunnel))

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -1611,6 +1611,10 @@ fn compile_value_expr(
                 .into());
             }
             Ok(CompiledExpr {
+                // For a naive `timestamp` input the ::timestamptz cast resolves
+                // against the session zone, which DatabasePool::connect pins to
+                // the configured display timezone. Unpinned this read naive
+                // wall-clock values as the server's zone and skewed every age.
                 sql: format!("AGE(CURRENT_TIMESTAMP, ({})::timestamptz)", value.sql),
                 info: ExpressionInfo {
                     data_type: "interval".to_string(),
@@ -1633,6 +1637,9 @@ fn compile_value_expr(
                 PlannerDateBucket::Week => "week",
             };
             Ok(CompiledExpr {
+                // DATE_TRUNC and the ::date cast both resolve against the
+                // session zone, pinned by DatabasePool::connect. Unpinned, a
+                // 07:00 +08 row bucketed into the previous UTC day.
                 sql: format!(
                     "DATE_TRUNC('{bucket_sql}', ({})::timestamptz)::date",
                     value.sql
@@ -1653,6 +1660,9 @@ fn compile_value_expr(
                 )
                 .into());
             }
+            // EXTRACT and TO_CHAR read the session zone, pinned by
+            // DatabasePool::connect. Unpinned, weekday grouping was misassigned
+            // for every row within the UTC offset of a day boundary.
             let (sql, data_type, display_type) = match part {
                 PlannerDatePart::Year => (
                     format!("EXTRACT(YEAR FROM ({})::timestamptz)::integer", value.sql),
@@ -3767,17 +3777,31 @@ fn pg_value_to_json(row: &sqlx::postgres::PgRow, col: &str, data_type: &str) -> 
             .try_get::<chrono::NaiveDateTime, _>(col)
             .map(|v| Value::String(v.format("%Y-%m-%d %H:%M:%S").to_string()))
             .unwrap_or(Value::Null),
+        // Rendered in the configured display timezone, carrying that zone's real
+        // offset. Emitting UTC here meant the grid showed local time while the
+        // value it came from — and the tooltip built off it — claimed +00:00.
         "timestamp with time zone" => row
             .try_get::<chrono::DateTime<chrono::Utc>, _>(col)
-            .map(|v| Value::String(v.to_rfc3339()))
+            .map(|v| {
+                Value::String(super::timezone::format_timestamptz(
+                    v,
+                    super::timezone::display_timezone(),
+                ))
+            })
             .unwrap_or(Value::Null),
         "date" => row
             .try_get::<chrono::NaiveDate, _>(col)
             .map(|v| Value::String(v.format("%Y-%m-%d").to_string()))
             .unwrap_or(Value::Null),
-        "time without time zone" | "time with time zone" => row
+        "time without time zone" => row
             .try_get::<chrono::NaiveTime, _>(col)
             .map(|v| Value::String(v.format("%H:%M:%S").to_string()))
+            .unwrap_or(Value::Null),
+        // `timetz` carries an offset that a NaiveTime decode discarded, so
+        // 09:00+08 and 09:00+00 rendered identically. PgTimeTz keeps both parts.
+        "time with time zone" => row
+            .try_get::<PgTimeTzChrono, _>(col)
+            .map(|v| Value::String(format_timetz(v)))
             .unwrap_or(Value::Null),
         "uuid" => row
             .try_get::<uuid::Uuid, _>(col)
@@ -3799,6 +3823,27 @@ fn pg_value_to_json(row: &sqlx::postgres::PgRow, col: &str, data_type: &str) -> 
             .map(Value::from)
             .unwrap_or(Value::Null),
     }
+}
+
+/// `timetz` as decoded with the `chrono` feature. The type params are spelled
+/// out rather than left to `PgTimeTz`'s defaults so this keeps compiling if the
+/// `time` feature is ever enabled alongside `chrono`.
+pub(crate) type PgTimeTzChrono =
+    sqlx::postgres::types::PgTimeTz<chrono::NaiveTime, chrono::FixedOffset>;
+
+/// Render a `timetz` as `HH:MM:SS±HH:MM`, keeping the offset the column stores.
+/// A whole-hour offset still prints its minutes so the value stays parseable by
+/// `Date`/`Intl` on the frontend.
+pub(crate) fn format_timetz(value: PgTimeTzChrono) -> String {
+    let total_minutes = value.offset.local_minus_utc() / 60;
+    let sign = if total_minutes < 0 { '-' } else { '+' };
+    let abs = total_minutes.abs();
+    format!(
+        "{}{sign}{:02}:{:02}",
+        value.time.format("%H:%M:%S"),
+        abs / 60,
+        abs % 60
+    )
 }
 
 /// Render a host address without the redundant /32 (v4) or /128 (v6) suffix;
@@ -3846,6 +3891,37 @@ fn is_text_type(data_type: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn timetz_keeps_its_offset() {
+        let time = chrono::NaiveTime::from_hms_opt(9, 0, 0).expect("valid time");
+        let plus_eight = PgTimeTzChrono {
+            time,
+            offset: chrono::FixedOffset::east_opt(8 * 3600).expect("valid offset"),
+        };
+        let utc = PgTimeTzChrono {
+            time,
+            offset: chrono::FixedOffset::east_opt(0).expect("valid offset"),
+        };
+        // These two rendered identically before the offset was preserved.
+        assert_eq!(format_timetz(plus_eight), "09:00:00+08:00");
+        assert_eq!(format_timetz(utc), "09:00:00+00:00");
+    }
+
+    #[test]
+    fn timetz_renders_negative_and_half_hour_offsets() {
+        let time = chrono::NaiveTime::from_hms_opt(9, 0, 0).expect("valid time");
+        let west = PgTimeTzChrono {
+            time,
+            offset: chrono::FixedOffset::west_opt(5 * 3600 + 1800).expect("valid offset"),
+        };
+        let kolkata = PgTimeTzChrono {
+            time,
+            offset: chrono::FixedOffset::east_opt(5 * 3600 + 1800).expect("valid offset"),
+        };
+        assert_eq!(format_timetz(west), "09:00:00-05:30");
+        assert_eq!(format_timetz(kolkata), "09:00:00+05:30");
+    }
 
     fn expression_info(data_type: &str, display_type: &str) -> ExpressionInfo {
         ExpressionInfo {

--- a/src/db/timezone.rs
+++ b/src/db/timezone.rs
@@ -1,0 +1,168 @@
+//! The single source of truth for "what timezone does the user think in".
+//!
+//! Three zones used to be in play independently — the Postgres session zone
+//! (never set, so whatever the server defaulted to), the UTC we serialized
+//! `timestamptz` into, and the browser's local zone that rendered it. Nothing
+//! made them agree, so a grid cell, its tooltip, the CSV export and a
+//! `DATE_TRUNC` day bucket could each disagree by the UTC offset.
+//!
+//! Now one configured zone (`[display] timezone`, default UTC) is resolved once
+//! at startup and applied in every layer:
+//!
+//! 1. the Postgres session (`SET TimeZone`), so all SQL-side date math —
+//!    `DATE_TRUNC`, `EXTRACT`, `AGE`, and text→`timestamptz` filter casts —
+//!    is evaluated against it;
+//! 2. Rust serialization, so the wire value carries that zone's real offset
+//!    instead of a hardcoded `+00:00`;
+//! 3. the frontend, which formats in it rather than the viewer's local zone.
+
+use std::sync::OnceLock;
+
+use chrono::{DateTime, SecondsFormat, Utc};
+use chrono_tz::Tz;
+
+/// Resolved once during startup. Read through [`display_timezone`], which falls
+/// back to UTC so unit tests and setup mode behave predictably without it set.
+static DISPLAY_TIMEZONE: OnceLock<Tz> = OnceLock::new();
+
+/// Parse an IANA timezone name (e.g. `Asia/Singapore`).
+///
+/// Rejects anything chrono-tz does not recognise, which also keeps the value
+/// safe to hand to Postgres — but callers must still bind it as a parameter
+/// rather than interpolate, see [`session_timezone_sql`].
+pub fn parse(name: &str) -> anyhow::Result<Tz> {
+    name.parse::<Tz>()
+        .map_err(|_| anyhow::anyhow!("Unknown timezone {name:?} — expected an IANA name such as \"Asia/Singapore\" or \"UTC\""))
+}
+
+/// Install the process-wide display timezone. Called once from startup, after
+/// config validation has already proven the name parses.
+///
+/// Returns the zone actually in effect: a second call is ignored (the first
+/// wins) rather than panicking, so a setup-mode reconfigure cannot abort the
+/// server. That case is logged by the caller.
+pub fn set_display_timezone(tz: Tz) -> Tz {
+    *DISPLAY_TIMEZONE.get_or_init(|| tz)
+}
+
+/// The configured display timezone, or UTC if none was installed.
+pub fn display_timezone() -> Tz {
+    *DISPLAY_TIMEZONE.get().unwrap_or(&Tz::UTC)
+}
+
+/// SQL that pins a connection's session timezone.
+///
+/// `SET TimeZone` will not accept a bind parameter, so this uses `set_config`,
+/// which will — the zone name never reaches the SQL text. `false` makes it
+/// session-scoped rather than transaction-local.
+pub const fn session_timezone_sql() -> &'static str {
+    "SELECT set_config('TimeZone', $1, false)"
+}
+
+/// Render an instant as RFC 3339 in `tz`, carrying that zone's real offset.
+///
+/// Previously `timestamptz` was serialized as `DateTime<Utc>::to_rfc3339()`, so
+/// every value claimed `+00:00` regardless of what the reader was shown. The
+/// offset here is looked up per-instant, so DST transitions land correctly.
+/// `AutoSi` keeps sub-second digits only when the value actually has them, so
+/// microsecond-precision columns are not silently truncated on export.
+pub fn format_timestamptz(value: DateTime<Utc>, tz: Tz) -> String {
+    value
+        .with_timezone(&tz)
+        .to_rfc3339_opts(SecondsFormat::AutoSi, false)
+}
+
+/// Short label for the zone at a given instant (e.g. `+08`, `UTC`), for
+/// annotating column headers and the CSV so a bare timestamp is not ambiguous.
+pub fn offset_label(at: DateTime<Utc>, tz: Tz) -> String {
+    if tz == Tz::UTC {
+        return "UTC".to_string();
+    }
+    // %:z yields "+08:00"; trim a whole-hour offset to "+08" to stay narrow in
+    // a column header, but keep the minutes for zones like +05:30.
+    let offset = at.with_timezone(&tz).format("%:z").to_string();
+    match offset.strip_suffix(":00") {
+        Some(hours) => hours.to_string(),
+        None => offset,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn instant(y: i32, m: u32, d: u32, h: u32, min: u32) -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(y, m, d, h, min, 0)
+            .single()
+            .expect("test instant should be unambiguous")
+    }
+
+    #[test]
+    fn parses_iana_names() {
+        assert_eq!(parse("Asia/Singapore").expect("should parse"), Tz::Asia__Singapore);
+        assert_eq!(parse("UTC").expect("should parse"), Tz::UTC);
+    }
+
+    #[test]
+    fn rejects_unknown_names() {
+        let err = parse("Mars/Olympus").expect_err("unknown zone must be rejected");
+        assert!(
+            err.to_string().contains("Unknown timezone"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_offset_shorthand() {
+        // "+08:00" is not an IANA name — accepting it would silently drop DST
+        // rules for zones that have them.
+        parse("+08:00").expect_err("offset shorthand must be rejected");
+    }
+
+    #[test]
+    fn formats_with_real_offset_not_utc() {
+        // 06:30Z is 14:30 in Singapore — the serialized value must say so
+        // rather than claiming +00:00 while the grid renders 14:30.
+        let formatted = format_timestamptz(instant(2026, 7, 30, 6, 30), Tz::Asia__Singapore);
+        assert_eq!(formatted, "2026-07-30T14:30:00+08:00");
+    }
+
+    #[test]
+    fn formats_utc_unchanged() {
+        let formatted = format_timestamptz(instant(2026, 7, 30, 6, 30), Tz::UTC);
+        assert_eq!(formatted, "2026-07-30T06:30:00+00:00");
+    }
+
+    #[test]
+    fn offset_is_looked_up_per_instant_across_dst() {
+        // London is +01:00 in July and +00:00 in January. A fixed offset
+        // captured once at startup would get one of these wrong.
+        let summer = format_timestamptz(instant(2026, 7, 30, 12, 0), Tz::Europe__London);
+        let winter = format_timestamptz(instant(2026, 1, 30, 12, 0), Tz::Europe__London);
+        assert_eq!(summer, "2026-07-30T13:00:00+01:00");
+        assert_eq!(winter, "2026-01-30T12:00:00+00:00");
+    }
+
+    #[test]
+    fn offset_label_trims_whole_hours() {
+        assert_eq!(offset_label(instant(2026, 7, 30, 6, 30), Tz::Asia__Singapore), "+08");
+        assert_eq!(offset_label(instant(2026, 7, 30, 6, 30), Tz::UTC), "UTC");
+    }
+
+    #[test]
+    fn offset_label_keeps_half_hour_minutes() {
+        assert_eq!(
+            offset_label(instant(2026, 7, 30, 6, 30), Tz::Asia__Kolkata),
+            "+05:30"
+        );
+    }
+
+    #[test]
+    fn display_timezone_defaults_to_utc_when_unset() {
+        // Other tests in this binary may have installed a zone already, so this
+        // only asserts the accessor never panics and yields a usable zone.
+        let tz = display_timezone();
+        assert!(!tz.name().is_empty());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,8 +37,12 @@ async fn main() -> anyhow::Result<()> {
             config.tables.warn_overlaps();
             let secrets = SecretsConfig::load_from_cwd();
             let ssh_pair = config.ssh.as_ref().map(|s| (s, &secrets));
+            // Validated during AppConfig::parse, so this cannot fail here.
+            let display_tz = config.display.resolved_timezone()?;
+            crate::db::timezone::set_display_timezone(display_tz);
+            tracing::info!(timezone = %display_tz.name(), "Display timezone");
             tracing::info!("Connecting to database...");
-            let db = DatabasePool::connect(&config.database, ssh_pair).await?;
+            let db = DatabasePool::connect(&config.database, ssh_pair, display_tz).await?;
             tracing::info!("Connected to database");
             initial_mode(Some(AppState { db, config }))
         }


### PR DESCRIPTION
Fixes #134.

> [!WARNING]
> **Draft: this has never been compiled or tested.** There is no Rust or Node toolchain on the machine it was written on, so `cargo build`, `cargo clippy` and `vitest` have never run against it. It also adds a `chrono-tz` dependency, so `Cargo.lock` needs regenerating. Treat the test expectations as intent, not as passing.

## What was wrong

Three timezones were in play with nothing making them agree — the Postgres session zone (never set, so whatever the server defaulted to), the UTC we serialized `timestamptz` into, and the browser's local zone that rendered it. Each layer independently picked one, so a grid cell, its tooltip, the CSV export and a `DATE_TRUNC` day bucket could each disagree by the UTC offset. See #134 for the full breakdown with line references.

## The approach

One configured zone, resolved once at startup, applied in all four layers rather than four independent guesses.

`[display] timezone` takes an IANA name and defaults to `UTC`. An unparseable value is rejected at config load — a silent fallback would shift every timestamp and every date bucket without the operator noticing the typo.

That single value then drives:

| Layer | Change |
|---|---|
| Postgres session | Pinned via `after_connect` so pool growth and reconnects agree with the first connection |
| `timestamptz` serialization | Rendered in that zone with its real offset, per-instant so DST lands correctly |
| Frontend | `Intl`'s `timeZone` option instead of the viewer's local zone |
| CSV export | Same serialization as the grid |

Two details worth flagging for review:

- The session pin uses `set_config('TimeZone', $1, false)` rather than `SET TIME ZONE`, which accepts no bind parameter. The zone name never enters SQL text.
- Offset-less `timestamp` values are rendered from their **literal parts**, not pushed through `Intl`. They are already wall-clock in the display zone, so converting them would shift them by the browser-vs-display difference. This is why `formatNaiveDateTime` exists rather than reusing the shared path.

## Fixes, mapped to the issue

1. **Grid/tooltip disagreement** — `timestamptz` now serializes with the display zone's real offset, so the tooltip and the cell describe the same moment in the same zone.
2. **View-builder date math** — pinning the session fixes `DATE_TRUNC` day/week buckets, `EXTRACT` year/month, `TO_CHAR` weekday and `AGE` together. Left the planner SQL alone and commented the dependency instead of restructuring the most intricate code in the repo.
3. **Filter casts** — fixed by the same pin; text→`timestamptz` now resolves in the display zone.
4. **CSV vs grid** — both paths share one formatter.
5. **Naive `timestamp` per-viewer shift** — rendered from literal parts, so the same row reads the same for every viewer.
6. **`timetz` dropped its offset** — decoded via `PgTimeTz` instead of `NaiveTime`; `09:00+08` and `09:00+00` no longer render identically.

## Behaviour change to confirm before merge

Pinning the session zone **changes the output of existing saved views** that bucket by day or week, or use `EXTRACT`/`AGE`. A 07:00+08 row no longer lands in the previous UTC day. That is the correction landing rather than a regression, but it moves numbers people may have screenshotted — probably worth a release note, and worth someone confirming it is the intended semantics before this merges.

## Tests added (unrun)

- `src/db/timezone.rs` — offset formatting, per-instant DST lookup across a London summer/winter boundary, IANA parse rejection including `+08:00` shorthand
- `src/db/postgres.rs` — `timetz` rendering for positive, negative and half-hour offsets
- `src/config.rs` — default-to-UTC, IANA resolution, typo rejection, example-config validity
- `frontend/src/lib/data-grid.test.ts` — zone arithmetic, day-boundary crossing, naive values not shifting, bare-date not misparsed as an offset, unrecognised-zone fallback

Frontend time assertions derive their expectation from the same `Intl` call rather than hardcoding `14:30`, since the existing formatters use the ambient locale and would otherwise make these machine-dependent.

## Not done

No UI zone label. Once everything agrees a bare timestamp is at least no longer *contradictory*, but a `+08` affordance in the column header or CSV preamble would make it self-describing. Left out to keep this reviewable — happy to add it here or separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
