### PR TITLE
fix(db): apply one configured display timezone across grid, CSV, filters, and view SQL

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **seeKi** (2062 symbols, 5078 relationships, 177 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **seeKi** (2373 symbols, 5924 relationships, 203 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ Uses Rust edition **2024** (`Cargo.toml`). This requires rustc 1.85+.
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **seeKi** (2062 symbols, 5078 relationships, 177 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **seeKi** (2373 symbols, 5924 relationships, 203 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -391,6 +391,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1684,6 +1694,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2301,6 +2329,7 @@ dependencies = [
  "axum",
  "bytes",
  "chrono",
+ "chrono-tz",
  "csv",
  "dirs-next",
  "futures",
@@ -2487,6 +2516,12 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ tower-http = { version = "0.6", features = ["fs", "cors"] }
 sqlx = { version = "0.8", features = ["runtime-tokio", "tls-rustls", "postgres", "sqlite", "chrono", "uuid", "rust_decimal", "ipnet"] }
 rust_decimal = { version = "1", features = ["serde-str"] }
 chrono = { version = "0.4", features = ["serde"] }
+chrono-tz = "0.10"
 uuid = { version = "1", features = ["serde"] }
 
 # Serialization

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -80,6 +80,7 @@
   import { COLUMN_VISIBILITY_KEY_PREFIX, SIDEBAR_COLLAPSED_KEY } from './lib/constants';
   import {
     createGridRefreshController,
+    displayTimezone,
     sidebarMode,
     type GridRefreshSnapshot,
   } from './lib/stores';
@@ -174,6 +175,12 @@
   let relatedColumnsPickerOpen: boolean = $state(false);
   let queryResult: QueryResult | null = $state(null);
   let displayConfig: DisplayConfig | null = $state(null);
+
+  // Publish the configured zone so every grid and panel formats timestamps the same way.
+  $effect(() => {
+    displayTimezone.set(displayConfig?.timezone ?? 'UTC');
+  });
+
   let appSettings: SettingsEntries = $state({});
   let sidebarCollapsed: boolean = $state(
     typeof localStorage !== 'undefined' &&

--- a/frontend/src/components/DataGrid.svelte
+++ b/frontend/src/components/DataGrid.svelte
@@ -29,6 +29,7 @@
   } from '../lib/data-grid';
   import { isSensitiveColumn } from '../lib/sensitive-columns';
   import { SKELETON_ROW_MARKER } from '../lib/infinite-scroll';
+  import { displayTimezone } from '../lib/stores';
 
   let {
     columns = [],
@@ -390,7 +391,12 @@
       );
     }
 
-    const formatted = formatCellValue(info, props.value, dateFormat);
+    const formatted = formatCellValue(
+      info,
+      props.value,
+      dateFormat,
+      $displayTimezone,
+    );
 
     // Determine column-level alignment from data type so every cell in the column
     // (including nulls) lines up consistently regardless of the individual value.

--- a/frontend/src/components/PeekPanel.svelte
+++ b/frontend/src/components/PeekPanel.svelte
@@ -4,6 +4,7 @@
   import { formatCellValue, getColumnDisplayName } from '../lib/data-grid';
   import { isSensitiveColumn } from '../lib/sensitive-columns';
   import { peekCanJump, peekPanelState } from '../lib/peek-panel';
+  import { displayTimezone } from '../lib/stores';
 
   let {
     open = false,
@@ -81,7 +82,7 @@
           {@const fields = row ?? {}}
           <dl class="peek-panel__fields">
             {#each columns as column (column.name)}
-              {@const formatted = formatCellValue(column, fields[column.name])}
+              {@const formatted = formatCellValue(column, fields[column.name], 'system', $displayTimezone)}
               <div class="peek-panel__field">
                 <dt>{getColumnDisplayName(column)}</dt>
                 <dd class:is-null={formatted.kind === 'null'}>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -359,7 +359,7 @@ export async function fetchTableRow(
 export async function fetchDisplayConfig(): Promise<DisplayConfig> {
   if (USE_MOCK) return mockFetchDisplayConfig();
   const data = await apiFetch<DisplayConfig>('/api/config/display');
-  assertShape(data, ['branding', 'tables'], '/api/config/display');
+  assertShape(data, ['branding', 'timezone', 'tables'], '/api/config/display');
   return data;
 }
 

--- a/frontend/src/lib/data-grid.test.ts
+++ b/frontend/src/lib/data-grid.test.ts
@@ -154,6 +154,83 @@ describe('formatCellValue', () => {
     });
   });
 
+  describe('timezone handling', () => {
+    const tzCol = col({ data_type: 'timestamp with time zone' });
+    const naiveCol = col({ data_type: 'timestamp without time zone' });
+
+    it('renders timestamptz in the display zone, not the runner zone', () => {
+      const result = formatCellValue(
+        tzCol,
+        '2024-01-15T22:30:00+08:00',
+        'YYYY-MM-DD',
+        'Asia/Singapore',
+      );
+      expect(result.display).toContain('2024-01-15');
+      expect(result.display).toMatch(/22:30|10:30/);
+      expect(result.tooltip).toBe('2024-01-15T22:30:00+08:00');
+    });
+
+    it('renders the same instant in UTC when the display zone is UTC', () => {
+      const result = formatCellValue(
+        tzCol,
+        '2024-01-15T22:30:00+08:00',
+        'YYYY-MM-DD',
+        'UTC',
+      );
+      expect(result.display).toContain('2024-01-15');
+      expect(result.display).toMatch(/14:30|2:30/);
+    });
+
+    it('applies daylight saving for America/New_York', () => {
+      const winter = formatCellValue(
+        tzCol,
+        '2024-03-09T12:00:00Z',
+        'YYYY-MM-DD',
+        'America/New_York',
+      );
+      const summer = formatCellValue(
+        tzCol,
+        '2024-03-11T12:00:00Z',
+        'YYYY-MM-DD',
+        'America/New_York',
+      );
+      expect(winter.display).toMatch(/07:00|7:00/);
+      expect(summer.display).toMatch(/08:00|8:00/);
+    });
+
+    it('renders a naive timestamp verbatim, whatever the display zone', () => {
+      const result = formatCellValue(
+        naiveCol,
+        '2024-01-15 14:30:00',
+        'YYYY-MM-DD',
+        'Pacific/Kiritimati',
+      );
+      expect(result.display).toContain('2024-01-15');
+      expect(result.display).toMatch(/14:30|2:30/);
+      expect(result.tooltip).toBe('2024-01-15 14:30:00');
+    });
+
+    it('ignores the display zone for a date-only value', () => {
+      const dateCol = col({ data_type: 'date' });
+      const utc = formatCellValue(dateCol, '2024-06-15', 'YYYY-MM-DD', 'UTC');
+      const kiritimati = formatCellValue(
+        dateCol,
+        '2024-06-15',
+        'YYYY-MM-DD',
+        'Pacific/Kiritimati',
+      );
+      expect(utc.display).toBe('2024-06-15');
+      expect(kiritimati.display).toBe('2024-06-15');
+    });
+
+    it('renders a timetz value as text, offset suffix intact', () => {
+      const timetzCol = col({ data_type: 'time with time zone' });
+      const result = formatCellValue(timetzCol, '14:30:00+08:00');
+      expect(result.kind).toBe('text');
+      expect(result.display).toBe('14:30:00+08:00');
+    });
+  });
+
   describe('numeric (precision-safe)', () => {
     const numericCol = col({ data_type: 'numeric' });
 

--- a/frontend/src/lib/data-grid.ts
+++ b/frontend/src/lib/data-grid.ts
@@ -26,11 +26,24 @@ const DATE_ONLY_TYPES = new Set([
   'date',
 ]);
 
-const DATETIME_TYPES = new Set([
-  'timestamp',
-  'timestamp without time zone',
+// Values of this type arrive as RFC 3339 strings that carry a real offset, so the
+// frontend resolves the exact instant and renders it in the configured display zone.
+const TIMESTAMPTZ_TYPES = new Set([
   'timestamp with time zone',
 ]);
+
+// Values of these types carry no offset. The frontend renders the wall clock verbatim
+// and applies no zone conversion.
+const NAIVE_DATETIME_TYPES = new Set([
+  'timestamp',
+  'timestamp without time zone',
+]);
+
+// Matches "YYYY-MM-DD HH:MM[:SS[.fff]]" and the T-separated form. The pattern anchors at
+// both ends, so a string that carries a "Z" or a "+HH:MM" offset does not match here and
+// takes the instant path instead. The capture groups render the wall clock verbatim.
+const NAIVE_DATETIME_PATTERN =
+  /^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})(?::(\d{2}))?(?:\.\d+)?$/;
 
 const dateFormatter = new Intl.DateTimeFormat(undefined, {
   year: 'numeric',
@@ -50,6 +63,112 @@ const timeFormatter = new Intl.DateTimeFormat(undefined, {
   hour: 'numeric',
   minute: '2-digit',
 });
+
+// Intl.DateTimeFormat construction costs real time and formatCellValue runs per cell.
+// This cache keeps one formatter per (timezone, dateFormat) pair.
+const tzFormatters = new Map<string, Intl.DateTimeFormat>();
+
+function getZonedFormatter(timezone: string): Intl.DateTimeFormat {
+  const cached = tzFormatters.get(timezone);
+  if (cached) return cached;
+
+  let built: Intl.DateTimeFormat;
+  try {
+    built = new Intl.DateTimeFormat(undefined, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+      timeZone: timezone,
+    });
+  } catch {
+    // The backend validates the zone name at config load, so this branch is defense in
+    // depth only. Fall back to the viewer local zone rather than throw during render.
+    built = formatter;
+  }
+
+  tzFormatters.set(timezone, built);
+  return built;
+}
+
+const tzTimeFormatters = new Map<string, Intl.DateTimeFormat>();
+
+// Mirrors timeFormatter, with the display zone applied.
+function getZonedTimeFormatter(timezone: string): Intl.DateTimeFormat {
+  const cached = tzTimeFormatters.get(timezone);
+  if (cached) return cached;
+
+  let built: Intl.DateTimeFormat;
+  try {
+    built = new Intl.DateTimeFormat(undefined, {
+      hour: 'numeric',
+      minute: '2-digit',
+      timeZone: timezone,
+    });
+  } catch {
+    built = timeFormatter;
+  }
+
+  tzTimeFormatters.set(timezone, built);
+  return built;
+}
+
+interface ZonedParts {
+  year: string;
+  month: string;
+  day: string;
+  hour: string;
+  minute: string;
+}
+
+// Reads the calendar parts of an instant in the target zone. Date.getFullYear and its
+// siblings would report the viewer local zone, which reintroduces the shift this fixes.
+const tzPartsFormatters = new Map<string, Intl.DateTimeFormat | null>();
+
+// Mirrors tzFormatters. The options are fixed apart from the zone, so one formatter per
+// zone serves every cell and formatCellValue pays no construction cost per cell.
+function getZonedPartsFormatter(timezone: string): Intl.DateTimeFormat | null {
+  if (tzPartsFormatters.has(timezone)) {
+    return tzPartsFormatters.get(timezone) ?? null;
+  }
+
+  let built: Intl.DateTimeFormat | null;
+  try {
+    built = new Intl.DateTimeFormat('en-GB', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      hourCycle: 'h23',
+      timeZone: timezone,
+    });
+  } catch {
+    built = null;
+  }
+
+  tzPartsFormatters.set(timezone, built);
+  return built;
+}
+
+function zonedParts(date: Date, timezone: string): ZonedParts | null {
+  const formatterForZone = getZonedPartsFormatter(timezone);
+  if (!formatterForZone) return null;
+
+  const parts = formatterForZone.formatToParts(date);
+
+  const lookup = (type: string): string =>
+    parts.find((p) => p.type === type)?.value ?? '';
+
+  return {
+    year: lookup('year'),
+    month: lookup('month'),
+    day: lookup('day'),
+    hour: lookup('hour'),
+    minute: lookup('minute'),
+  };
+}
 
 export interface FormattedCellValue {
   kind: 'null' | 'boolean' | 'number' | 'timestamp' | 'text';
@@ -73,8 +192,11 @@ export function columnWidth(col: ColumnInfo): number {
     case 'date':
       return 132;
     case 'time without time zone':
-    case 'time with time zone':
       return 110;
+    // The backend appends the stored offset, for example "14:30:00+08:00", so this
+    // column needs about seven extra characters of room.
+    case 'time with time zone':
+      return 165;
     case 'timestamp':
     case 'timestamp without time zone':
     case 'timestamp with time zone':
@@ -137,6 +259,7 @@ export function formatCellValue(
   column: ColumnInfo,
   value: unknown,
   dateFormat: DateFormatPreference = 'system',
+  timezone: string = 'UTC',
 ): FormattedCellValue {
   if (value == null) {
     return {
@@ -169,18 +292,49 @@ export function formatCellValue(
     }
   }
 
-  if (
-    DATETIME_TYPES.has(column.data_type) ||
-    column.display_type === 'datetime'
-  ) {
+  if (TIMESTAMPTZ_TYPES.has(column.data_type)) {
     const raw = String(value);
-    // Replace space with T for ISO 8601 compliance — Safari rejects "2024-01-15 14:30:00"
-    const parsed = new Date(raw.replace(' ', 'T'));
+    // The string carries its own offset, so new Date resolves the exact instant. Intl
+    // then renders that instant in the display zone and handles daylight saving.
+    const parsed = new Date(raw);
 
     if (!Number.isNaN(parsed.getTime())) {
       return {
         kind: 'timestamp',
-        display: formatDateTime(parsed, dateFormat),
+        display: formatZonedDateTime(parsed, dateFormat, timezone),
+        tooltip: raw,
+      };
+    }
+  }
+
+  if (
+    NAIVE_DATETIME_TYPES.has(column.data_type) ||
+    column.display_type === 'datetime'
+  ) {
+    const raw = String(value);
+    // The string carries no offset. Render the captured parts verbatim and pin every Intl
+    // call to UTC. The local-time Date constructor would shift a wall clock that lands in
+    // the viewer own daylight saving gap, for example 02:30 on a spring-forward date.
+    const match = NAIVE_DATETIME_PATTERN.exec(raw);
+
+    if (match) {
+      const display = formatNaiveDateTime(match, dateFormat);
+      if (display) {
+        return {
+          kind: 'timestamp',
+          display,
+          tooltip: raw,
+        };
+      }
+    }
+
+    // The value carries an offset or a "Z" suffix, so it names a real instant. Resolve it
+    // and render it in the display zone, the same way a timestamptz column renders.
+    const parsed = new Date(raw);
+    if (!Number.isNaN(parsed.getTime())) {
+      return {
+        kind: 'timestamp',
+        display: formatZonedDateTime(parsed, dateFormat, timezone),
         tooltip: raw,
       };
     }
@@ -251,6 +405,80 @@ function formatDateTime(date: Date, dateFormat: DateFormatPreference): string {
   }
 
   return `${formatDate(date, dateFormat)} ${timeFormatter.format(date)}`;
+}
+
+// Renders a naive wall clock from its captured parts. No zone conversion happens. The
+// "system" branch needs Intl for the locale pattern, so it feeds Intl a UTC instant and a
+// UTC-pinned formatter. UTC has no daylight saving, so the parts survive the round trip.
+function formatNaiveDateTime(
+  match: RegExpExecArray,
+  dateFormat: DateFormatPreference,
+): string | null {
+  const year = match[1];
+  const month = match[2];
+  const day = match[3];
+  const hour = match[4];
+  const minute = match[5];
+
+  const instant = new Date(
+    Date.UTC(
+      Number(year),
+      Number(month) - 1,
+      Number(day),
+      Number(hour),
+      Number(minute),
+      Number(match[6] ?? '0'),
+    ),
+  );
+
+  if (Number.isNaN(instant.getTime())) {
+    return null;
+  }
+
+  if (dateFormat === 'system') {
+    return getZonedFormatter('UTC').format(instant);
+  }
+
+  const time = getZonedTimeFormatter('UTC').format(instant);
+
+  switch (dateFormat) {
+    case 'YYYY-MM-DD':
+      return `${year}-${month}-${day} ${time}`;
+    case 'DD/MM/YYYY':
+      return `${day}/${month}/${year} ${time}`;
+    case 'MM/DD/YYYY':
+      return `${month}/${day}/${year} ${time}`;
+    default:
+      return getZonedFormatter('UTC').format(instant);
+  }
+}
+
+function formatZonedDateTime(
+  date: Date,
+  dateFormat: DateFormatPreference,
+  timezone: string,
+): string {
+  if (dateFormat === 'system') {
+    return getZonedFormatter(timezone).format(date);
+  }
+
+  const parts = zonedParts(date, timezone);
+  if (!parts) {
+    return formatDateTime(date, dateFormat);
+  }
+
+  const time = getZonedTimeFormatter(timezone).format(date);
+
+  switch (dateFormat) {
+    case 'YYYY-MM-DD':
+      return `${parts.year}-${parts.month}-${parts.day} ${time}`;
+    case 'DD/MM/YYYY':
+      return `${parts.day}/${parts.month}/${parts.year} ${time}`;
+    case 'MM/DD/YYYY':
+      return `${parts.month}/${parts.day}/${parts.year} ${time}`;
+    default:
+      return getZonedFormatter(timezone).format(date);
+  }
 }
 
 export function buildSortableColumn(

--- a/frontend/src/lib/mock.test.ts
+++ b/frontend/src/lib/mock.test.ts
@@ -258,6 +258,11 @@ describe('mockFetchDisplayConfig', () => {
     expect(Object.keys(config.tables).length).toBeGreaterThan(0);
   });
 
+  it('returns UTC as the default display timezone', () => {
+    const config = mockFetchDisplayConfig();
+    expect(config.timezone).toBe('UTC');
+  });
+
   it('includes display names for all tables', () => {
     const tables = mockFetchTables();
     const config = mockFetchDisplayConfig();

--- a/frontend/src/lib/mock.ts
+++ b/frontend/src/lib/mock.ts
@@ -340,10 +340,12 @@ function pick<T>(arr: readonly T[]): T {
   return arr[Math.floor(Math.random() * arr.length)];
 }
 
+// Emits "YYYY-MM-DD HH:MM:SS", the naive form the backend sends for a timestamp column.
+// An ISO string with a "Z" suffix would name an instant, which the naive columns never do.
 function randomTimestamp(daysBack: number): string {
   const now = Date.now();
   const offset = Math.floor(Math.random() * daysBack * 86400000);
-  return new Date(now - offset).toISOString();
+  return new Date(now - offset).toISOString().slice(0, 19).replace('T', ' ');
 }
 
 function randomIp(): string {
@@ -825,6 +827,7 @@ export function mockFetchDisplayConfig(): DisplayConfig {
       title: 'SeeKi',
       subtitle: 'Database Viewer',
     },
+    timezone: 'UTC',
     tables: Object.fromEntries(
       TABLES.map((t) => [
         `${t.schema}.${t.name}`,

--- a/frontend/src/lib/settings.test.ts
+++ b/frontend/src/lib/settings.test.ts
@@ -14,6 +14,7 @@ const displayConfig: DisplayConfig = {
     title: 'SeeKi',
     subtitle: 'Database Viewer',
   },
+  timezone: 'UTC',
   tables: {},
 };
 

--- a/frontend/src/lib/stores.ts
+++ b/frontend/src/lib/stores.ts
@@ -10,6 +10,11 @@ import type { ColumnInfo, SettingsSection, SidebarMode } from './types';
 export const sidebarMode = writable<SidebarMode>('tables');
 export const activeSettingsSection = writable<SettingsSection>('updates');
 
+// IANA zone the backend reports through /api/config/display. Every timestamptz cell
+// renders in this zone, so all viewers see the same wall clock. "UTC" is the default
+// until App.svelte loads the display config.
+export const displayTimezone = writable<string>('UTC');
+
 type StorageLike = Pick<Storage, 'getItem' | 'setItem'>;
 
 function getBrowserStorage(): StorageLike | null {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -301,6 +301,9 @@ export interface DisplayConfig {
     title: string | null;
     subtitle: string | null;
   };
+  // IANA zone name, for example "Asia/Singapore". The backend rejects an invalid name at
+  // config load, so the frontend passes this string straight to Intl.DateTimeFormat.
+  timezone: string;
   // Keyed by qualified "schema.table" (including "public.table").
   tables: Record<
     string,

--- a/seeki.toml.example
+++ b/seeki.toml.example
@@ -16,6 +16,13 @@ max_connections = 5
 include = ["vehicles_log", "drivers", "audit_log"]
 exclude = ["audit_log"]
 
+# Display settings.
+# `timezone` is an IANA time zone name. SeeKi renders every timestamp in this
+# zone and pins the database session TimeZone to it. Default "UTC".
+# Example: timezone = "Asia/Singapore"
+[display]
+timezone = "UTC"
+
 # Optional sidebar display name overrides for tables.
 [display.tables]
 vehicles_log = "Fleet Log"

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -86,6 +86,9 @@ async fn require_state(mode: &SharedAppMode) -> Result<Arc<AppState>, AppError> 
 #[derive(Serialize)]
 struct DisplayConfigResponse {
     branding: BrandingResponse,
+    /// IANA zone name from config. The frontend passes it straight to
+    /// Intl.DateTimeFormat, because config load already validated it.
+    timezone: String,
     tables: HashMap<String, TableDisplayConfig>,
 }
 
@@ -184,6 +187,7 @@ async fn get_display_config(
             },
             &settings,
         ),
+        timezone: state.config.display.timezone.clone(),
         tables,
     }))
 }
@@ -791,16 +795,19 @@ async fn get_rows(
     let sort = parse_sort_param(params.sort.as_deref(), &columns)?;
     let result = state
         .db
-        .query_rows(&RowQueryParams {
-            schema: &schema,
-            table: &table,
-            page,
-            page_size,
-            sort: &sort,
-            search: params.search.as_deref(),
-            filters: &filters,
-            exact_filters: &exact_filters,
-        })
+        .query_rows(
+            &RowQueryParams {
+                schema: &schema,
+                table: &table,
+                page,
+                page_size,
+                sort: &sort,
+                search: params.search.as_deref(),
+                filters: &filters,
+                exact_filters: &exact_filters,
+            },
+            state.display_tz,
+        )
         .await
         .map_err(|e| map_table_query_error(e, &table))?;
     Ok(Json(serde_json::json!(result)))
@@ -841,7 +848,7 @@ async fn get_single_row(
 
     let (row, multiple) = state
         .db
-        .query_single_row(&schema, &table, &exact_filters)
+        .query_single_row(&schema, &table, &exact_filters, state.display_tz)
         .await
         .map_err(|e| map_table_query_error(e, &table))?;
 
@@ -932,6 +939,7 @@ async fn export_csv(
     let search = params.search.clone();
     let schema_owned = schema.clone();
     let sort_owned = sort;
+    let display_tz = state.display_tz;
 
     let (tx, rx) = tokio::sync::mpsc::channel::<Result<bytes::Bytes, std::io::Error>>(32);
 
@@ -982,7 +990,9 @@ async fn export_csv(
                 Ok(row) => {
                     let fields: Vec<String> = columns
                         .iter()
-                        .map(|col| pg_value_to_csv_string(&row, &col.name, &col.data_type))
+                        .map(|col| {
+                            pg_value_to_csv_string(&row, &col.name, &col.data_type, display_tz)
+                        })
                         .collect();
 
                     if wtr.write_record(&fields).is_err() {
@@ -1046,7 +1056,12 @@ async fn export_csv(
     ))
 }
 
-fn pg_value_to_csv_string(row: &sqlx::postgres::PgRow, col: &str, data_type: &str) -> String {
+fn pg_value_to_csv_string(
+    row: &sqlx::postgres::PgRow,
+    col: &str,
+    data_type: &str,
+    tz: chrono_tz::Tz,
+) -> String {
     use sqlx::Row;
     match data_type {
         "smallint" => row
@@ -1087,15 +1102,19 @@ fn pg_value_to_csv_string(row: &sqlx::postgres::PgRow, col: &str, data_type: &st
             .unwrap_or_default(),
         "timestamp with time zone" => row
             .try_get::<chrono::DateTime<chrono::Utc>, _>(col)
-            .map(|v| v.to_rfc3339())
+            .map(|v| crate::db::postgres::format_timestamptz(v, tz))
             .unwrap_or_default(),
         "date" => row
             .try_get::<chrono::NaiveDate, _>(col)
             .map(|v| v.format("%Y-%m-%d").to_string())
             .unwrap_or_default(),
-        "time without time zone" | "time with time zone" => row
+        "time without time zone" => row
             .try_get::<chrono::NaiveTime, _>(col)
             .map(|v| v.format("%H:%M:%S").to_string())
+            .unwrap_or_default(),
+        "time with time zone" => row
+            .try_get::<sqlx::postgres::types::PgTimeTz, _>(col)
+            .map(|v| crate::db::postgres::format_timetz(v.time, v.offset))
             .unwrap_or_default(),
         "uuid" => row
             .try_get::<uuid::Uuid, _>(col)
@@ -1238,6 +1257,7 @@ mod tests {
             .unwrap();
         let mode = initial_mode(Some(crate::AppState {
             db: crate::db::DatabasePool::Postgres(pool, None),
+            display_tz: config.display.parsed_timezone(),
             config,
         }));
         Router::new().nest("/api", router(mode, store))
@@ -1269,6 +1289,19 @@ mod tests {
         ]
     }
 
+    /// The CSV arm and the grid arm both call
+    /// `crate::db::postgres::format_timestamptz`, so both emit the same string.
+    /// This test pins the expected string on the API side, so a future edit that
+    /// gives CSV its own formatter fails here.
+    #[test]
+    fn csv_timestamptz_matches_the_grid_format() {
+        let instant = "2024-01-15T14:30:00Z"
+            .parse::<chrono::DateTime<chrono::Utc>>()
+            .expect("test timestamp parses");
+        let rendered = crate::db::postgres::format_timestamptz(instant, chrono_tz::Asia::Singapore);
+        assert_eq!(rendered, "2024-01-15T22:30:00+08:00");
+    }
+
     #[test]
     fn display_config_response_serializes_with_branding() {
         let response = DisplayConfigResponse {
@@ -1277,6 +1310,7 @@ mod tests {
                 subtitle: Some("Fleet Telemetry".into()),
             },
             tables: HashMap::new(),
+            timezone: "UTC".to_string(),
         };
 
         let json = serde_json::to_value(&response).unwrap();
@@ -1293,6 +1327,7 @@ mod tests {
                 subtitle: None,
             },
             tables: HashMap::new(),
+            timezone: "UTC".to_string(),
         };
 
         let json = serde_json::to_value(&response).unwrap();
@@ -1331,6 +1366,7 @@ mod tests {
                 subtitle: None,
             },
             tables,
+            timezone: "UTC".to_string(),
         };
 
         let json = serde_json::to_value(&response).unwrap();
@@ -1525,6 +1561,7 @@ mod tests {
         };
         let mode = initial_mode(Some(crate::AppState {
             db: crate::db::DatabasePool::Postgres(pool, None),
+            display_tz: config.display.parsed_timezone(),
             config,
         }));
         let app: Router = router(mode, store);
@@ -1891,6 +1928,7 @@ mod tests {
         let config = DisplayConfig {
             tables: HashMap::new(),
             columns: columns_map,
+            timezone: "UTC".to_string(),
         };
 
         let sibling_names: Vec<&str> = columns.iter().map(|c| c.name.as_str()).collect();
@@ -1934,6 +1972,7 @@ mod tests {
         let config = DisplayConfig {
             tables,
             columns: HashMap::new(),
+            timezone: "UTC".to_string(),
         };
 
         let display = display_name_table("public", "vehicles_log", &config)

--- a/src/api/setup.rs
+++ b/src/api/setup.rs
@@ -359,23 +359,28 @@ pub async fn save_config(
     };
 
     let ssh_ref = app_config.ssh.as_ref().map(|s| (s, &secrets));
-    let db = match DatabasePool::connect(&app_config.database, ssh_ref).await {
-        Ok(d) => d,
-        Err(e) => {
-            let _ = std::fs::remove_file("seeki.toml");
-            let _ = std::fs::remove_file(".seeki.secrets");
-            return Json(SaveConfigResponse {
-                success: false,
-                error: Some(format!("Failed to connect after saving config: {e}")),
-            })
-            .into_response();
-        }
-    };
+    let db =
+        match DatabasePool::connect(&app_config.database, ssh_ref, &app_config.display.timezone)
+            .await
+        {
+            Ok(d) => d,
+            Err(e) => {
+                let _ = std::fs::remove_file("seeki.toml");
+                let _ = std::fs::remove_file(".seeki.secrets");
+                return Json(SaveConfigResponse {
+                    success: false,
+                    error: Some(format!("Failed to connect after saving config: {e}")),
+                })
+                .into_response();
+            }
+        };
 
     // 9. Swap mode to Normal
+    let display_tz = app_config.display.parsed_timezone();
     let new_state = Arc::new(AppState {
         db,
         config: app_config,
+        display_tz,
     });
     *mode.write().await = AppMode::Normal(new_state);
 
@@ -1121,7 +1126,12 @@ mod tests {
              [database]\nkind = \"postgres\"\nurl = \"postgres://u:p@localhost/db\"\n",
         )
         .expect("minimal config should parse");
-        let state = Arc::new(crate::AppState { db, config });
+        let display_tz = config.display.parsed_timezone();
+        let state = Arc::new(crate::AppState {
+            db,
+            config,
+            display_tz,
+        });
         Arc::new(tokio::sync::RwLock::new(AppMode::Normal(state)))
     }
 

--- a/src/api/views.rs
+++ b/src/api/views.rs
@@ -328,6 +328,7 @@ async fn create_saved_view(
                         filters: &legacy.filters,
                     },
                     1,
+                    state.display_tz,
                 )
                 .await?;
         }
@@ -343,6 +344,7 @@ async fn create_saved_view(
                 &body.base_table,
                 &body.shape,
                 1,
+                state.display_tz,
             )
             .await?;
         }
@@ -431,6 +433,7 @@ async fn preview_saved_view(
                         filters: &legacy.filters,
                     },
                     100,
+                    state.display_tz,
                 )
                 .await?
         }
@@ -446,6 +449,7 @@ async fn preview_saved_view(
                 &body.base_table,
                 &body.shape,
                 100,
+                state.display_tz,
             )
             .await?
         }
@@ -478,20 +482,23 @@ async fn query_transient_view(
         PlannerCompatibility::Legacy(legacy) => {
             state
                 .db
-                .query_view_rows(&ViewRowsQueryParams {
-                    draft: ViewDraft {
-                        base_schema: &body.base_schema,
-                        base_table: &body.base_table,
-                        columns: &legacy.columns,
-                        filters: &legacy.filters,
+                .query_view_rows(
+                    &ViewRowsQueryParams {
+                        draft: ViewDraft {
+                            base_schema: &body.base_schema,
+                            base_table: &body.base_table,
+                            columns: &legacy.columns,
+                            filters: &legacy.filters,
+                        },
+                        page,
+                        page_size,
+                        sort: &sort,
+                        search: body.search.as_deref(),
+                        filters: &body.filters,
+                        exact_filters: &body.exact_filters,
                     },
-                    page,
-                    page_size,
-                    sort: &sort,
-                    search: body.search.as_deref(),
-                    filters: &body.filters,
-                    exact_filters: &body.exact_filters,
-                })
+                    state.display_tz,
+                )
                 .await?
         }
         PlannerCompatibility::RequiresPlannerV2(_) => {
@@ -511,6 +518,7 @@ async fn query_transient_view(
                 body.search.as_deref(),
                 &body.filters,
                 &body.exact_filters,
+                state.display_tz,
             )
             .await?
         }
@@ -606,20 +614,23 @@ async fn get_saved_view_rows(
         PlannerCompatibility::Legacy(legacy) => {
             state
                 .db
-                .query_view_rows(&ViewRowsQueryParams {
-                    draft: ViewDraft {
-                        base_schema: &view.base_schema,
-                        base_table: &view.base_table,
-                        columns: &legacy.columns,
-                        filters: &legacy.filters,
+                .query_view_rows(
+                    &ViewRowsQueryParams {
+                        draft: ViewDraft {
+                            base_schema: &view.base_schema,
+                            base_table: &view.base_table,
+                            columns: &legacy.columns,
+                            filters: &legacy.filters,
+                        },
+                        page: params.page.max(1),
+                        page_size: params.page_size.clamp(1, super::MAX_PAGE_SIZE),
+                        sort: &sort,
+                        search: params.search.as_deref(),
+                        filters: &filters,
+                        exact_filters: &exact_filters,
                     },
-                    page: params.page.max(1),
-                    page_size: params.page_size.clamp(1, super::MAX_PAGE_SIZE),
-                    sort: &sort,
-                    search: params.search.as_deref(),
-                    filters: &filters,
-                    exact_filters: &exact_filters,
-                })
+                    state.display_tz,
+                )
                 .await?
         }
         PlannerCompatibility::RequiresPlannerV2(_) => {
@@ -639,6 +650,7 @@ async fn get_saved_view_rows(
                 params.search.as_deref(),
                 &filters,
                 &exact_filters,
+                state.display_tz,
             )
             .await?
         }
@@ -697,6 +709,7 @@ async fn export_saved_view_csv(
     let sort_owned = sort;
     let search_owned = params.search.clone();
     let filters_owned = filters;
+    let display_tz = state.display_tz;
 
     tokio::spawn(async move {
         use futures::StreamExt;
@@ -775,7 +788,12 @@ async fn export_saved_view_csv(
                     let fields: Vec<String> = columns
                         .iter()
                         .map(|column| {
-                            super::pg_value_to_csv_string(&row, &column.name, &column.data_type)
+                            super::pg_value_to_csv_string(
+                                &row,
+                                &column.name,
+                                &column.data_type,
+                                display_tz,
+                            )
                         })
                         .collect();
                     if writer.write_record(&fields).is_err() {
@@ -877,6 +895,7 @@ mod tests {
             .unwrap();
         let mode = initial_mode(Some(crate::AppState {
             db: crate::db::DatabasePool::Postgres(pool, None),
+            display_tz: config.display.parsed_timezone(),
             config,
         }));
 
@@ -920,6 +939,7 @@ mod tests {
         let mode = initial_mode(Some(crate::AppState {
             db: crate::db::DatabasePool::Postgres(pool, None),
             config: test_app_config(),
+            display_tz: chrono_tz::UTC,
         }));
         let app = Router::new().nest("/api", crate::api::router(mode, store));
         (app, created.id, dir)

--- a/src/config.rs
+++ b/src/config.rs
@@ -99,12 +99,37 @@ impl TablesConfig {
     }
 }
 
-#[derive(Debug, Deserialize, Default)]
+#[derive(Debug, Deserialize)]
 pub struct DisplayConfig {
     #[serde(default)]
     pub tables: HashMap<String, String>,
     #[serde(default)]
     pub columns: HashMap<String, HashMap<String, String>>,
+    /// IANA time zone name used to render timestamps and to pin the database
+    /// session TimeZone. Config load rejects an invalid name, so every reader
+    /// can treat this value as parseable.
+    #[serde(default = "default_timezone")]
+    pub timezone: String,
+}
+
+impl Default for DisplayConfig {
+    fn default() -> Self {
+        Self {
+            tables: HashMap::new(),
+            columns: HashMap::new(),
+            timezone: default_timezone(),
+        }
+    }
+}
+
+impl DisplayConfig {
+    /// Parse the configured zone. AppConfig::validate rejects an invalid name at
+    /// load time, so this call cannot fail on a loaded config.
+    pub fn parsed_timezone(&self) -> chrono_tz::Tz {
+        self.timezone
+            .parse::<chrono_tz::Tz>()
+            .unwrap_or(chrono_tz::UTC)
+    }
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -195,6 +220,10 @@ fn default_port() -> u16 {
 
 fn default_max_connections() -> u32 {
     5
+}
+
+fn default_timezone() -> String {
+    "UTC".to_string()
 }
 
 pub fn display_name_table(schema: &str, table: &str, config: &DisplayConfig) -> String {
@@ -347,6 +376,12 @@ impl AppConfig {
         {
             anyhow::bail!(
                 "database.schemas must not be empty — remove the key to default to [\"public\"]"
+            );
+        }
+        if self.display.timezone.parse::<chrono_tz::Tz>().is_err() {
+            anyhow::bail!(
+                "display.timezone \"{}\" is not a valid IANA time zone name. Use a name such as \"Asia/Singapore\" or \"UTC\".",
+                self.display.timezone
             );
         }
         Ok(())
@@ -754,6 +789,7 @@ subtitle = "Fleet Telemetry"
         let config = DisplayConfig {
             tables,
             columns: std::collections::HashMap::new(),
+            timezone: "UTC".to_string(),
         };
 
         // Qualified key matches.
@@ -776,6 +812,7 @@ subtitle = "Fleet Telemetry"
         assert!(config.tables.include.is_some());
         assert!(!config.display.tables.is_empty());
         assert!(!config.display.columns.is_empty());
+        assert_eq!(config.display.timezone, "UTC");
         assert_eq!(config.branding.title.as_deref(), Some("My Database"));
         assert_eq!(config.branding.subtitle.as_deref(), Some("Fleet Telemetry"));
         assert_eq!(
@@ -1020,6 +1057,54 @@ schemas = ["public", "reporting"]
         assert_eq!(
             config.database.effective_schemas(),
             vec!["public".to_string(), "reporting".to_string()]
+        );
+    }
+
+    #[test]
+    fn display_timezone_parses_and_round_trips() {
+        let toml = r#"
+[server]
+host = "127.0.0.1"
+port = 3141
+[database]
+url = "postgres://u:p@localhost/db"
+[display]
+timezone = "Asia/Singapore"
+"#;
+        let config = AppConfig::parse(toml).expect("config with a valid zone parses");
+        assert_eq!(config.display.timezone, "Asia/Singapore");
+        assert_eq!(config.display.parsed_timezone(), chrono_tz::Asia::Singapore);
+    }
+
+    #[test]
+    fn display_timezone_defaults_to_utc() {
+        let toml = r#"
+[server]
+host = "127.0.0.1"
+port = 3141
+[database]
+url = "postgres://u:p@localhost/db"
+"#;
+        let config = AppConfig::parse(toml).expect("config without a zone parses");
+        assert_eq!(config.display.timezone, "UTC");
+        assert_eq!(config.display.parsed_timezone(), chrono_tz::UTC);
+    }
+
+    #[test]
+    fn invalid_display_timezone_rejected_at_load() {
+        let toml = r#"
+[server]
+host = "127.0.0.1"
+port = 3141
+[database]
+url = "postgres://u:p@localhost/db"
+[display]
+timezone = "Mars/Olympus"
+"#;
+        let err = AppConfig::parse(toml).expect_err("an invalid zone should be rejected");
+        assert!(
+            err.to_string().contains("Mars/Olympus"),
+            "unexpected error: {err}"
         );
     }
 

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -548,6 +548,7 @@ impl DatabasePool {
     pub async fn connect(
         config: &DatabaseConfig,
         ssh: Option<(&crate::config::SshConfig, &crate::config::SecretsConfig)>,
+        display_timezone: &str,
     ) -> anyhow::Result<Self> {
         match config.kind {
             DatabaseKind::Postgres => {
@@ -577,8 +578,24 @@ impl DatabasePool {
                     (config.url.clone(), None)
                 };
 
+                // Pin the session TimeZone on every pooled connection so date
+                // arithmetic and timestamptz rendering follow the configured
+                // display zone instead of the server default. is_local=false
+                // keeps the setting for the whole session, because a pooled
+                // connection outlives any single transaction.
+                let tz = display_timezone.to_string();
                 let pool = sqlx::postgres::PgPoolOptions::new()
                     .max_connections(config.max_connections)
+                    .after_connect(move |conn, _meta| {
+                        let tz = tz.clone();
+                        Box::pin(async move {
+                            sqlx::query("SELECT set_config('TimeZone', $1, false)")
+                                .bind(tz)
+                                .execute(conn)
+                                .await?;
+                            Ok(())
+                        })
+                    })
                     .connect(&connect_url)
                     .await?;
                 // A new pool may point at a different database, so cached FK
@@ -691,9 +708,13 @@ impl DatabasePool {
         }
     }
 
-    pub async fn query_rows(&self, params: &RowQueryParams<'_>) -> anyhow::Result<QueryResult> {
+    pub async fn query_rows(
+        &self,
+        params: &RowQueryParams<'_>,
+        tz: chrono_tz::Tz,
+    ) -> anyhow::Result<QueryResult> {
         match self {
-            Self::Postgres(pool, _) => postgres::query_rows(pool, params).await,
+            Self::Postgres(pool, _) => postgres::query_rows(pool, params, tz).await,
         }
     }
 
@@ -704,10 +725,11 @@ impl DatabasePool {
         schema: &str,
         table: &str,
         exact_filters: &HashMap<String, String>,
+        tz: chrono_tz::Tz,
     ) -> anyhow::Result<(Option<serde_json::Value>, bool)> {
         match self {
             Self::Postgres(pool, _) => {
-                postgres::query_single_row(pool, schema, table, exact_filters).await
+                postgres::query_single_row(pool, schema, table, exact_filters, tz).await
             }
         }
     }
@@ -745,18 +767,20 @@ impl DatabasePool {
         &self,
         draft: &ViewDraft<'_>,
         page_size: u32,
+        tz: chrono_tz::Tz,
     ) -> anyhow::Result<QueryResult> {
         match self {
-            Self::Postgres(pool, _) => postgres::preview_view(pool, draft, page_size).await,
+            Self::Postgres(pool, _) => postgres::preview_view(pool, draft, page_size, tz).await,
         }
     }
 
     pub async fn query_view_rows(
         &self,
         params: &ViewRowsQueryParams<'_>,
+        tz: chrono_tz::Tz,
     ) -> anyhow::Result<QueryResult> {
         match self {
-            Self::Postgres(pool, _) => postgres::query_view_rows(pool, params).await,
+            Self::Postgres(pool, _) => postgres::query_view_rows(pool, params, tz).await,
         }
     }
 

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -3589,12 +3589,16 @@ async fn plan_view_shape_query(
     compile_planner_view_query(&planner_draft, &catalog)
 }
 
-fn rows_to_json(rows: &[sqlx::postgres::PgRow], columns: &[ColumnInfo]) -> Vec<serde_json::Value> {
+fn rows_to_json(
+    rows: &[sqlx::postgres::PgRow],
+    columns: &[ColumnInfo],
+    tz: chrono_tz::Tz,
+) -> Vec<serde_json::Value> {
     rows.iter()
         .map(|row| {
             let mut map = serde_json::Map::new();
             for col in columns {
-                let val = pg_value_to_json(row, &col.name, &col.data_type);
+                let val = pg_value_to_json(row, &col.name, &col.data_type, tz);
                 map.insert(col.name.clone(), val);
             }
             serde_json::Value::Object(map)
@@ -3612,6 +3616,7 @@ async fn query_projected_rows(
     search: Option<&str>,
     filters: &HashMap<String, String>,
     exact_filters: &HashMap<String, String>,
+    tz: chrono_tz::Tz,
 ) -> anyhow::Result<QueryResult> {
     let qb = build_query_clauses(
         &plan.output_columns,
@@ -3652,7 +3657,7 @@ async fn query_projected_rows(
 
     Ok(QueryResult {
         columns: plan.output_columns.clone(),
-        rows: rows_to_json(&rows, &plan.output_columns),
+        rows: rows_to_json(&rows, &plan.output_columns, tz),
         total_rows,
         page,
         page_size,
@@ -3663,6 +3668,7 @@ pub async fn preview_view(
     pool: &PgPool,
     draft: &ViewDraft<'_>,
     page_size: u32,
+    tz: chrono_tz::Tz,
 ) -> anyhow::Result<QueryResult> {
     if draft.columns.is_empty() {
         return Ok(QueryResult {
@@ -3684,6 +3690,7 @@ pub async fn preview_view(
         None,
         &HashMap::new(),
         &HashMap::new(),
+        tz,
     )
     .await
 }
@@ -3691,6 +3698,7 @@ pub async fn preview_view(
 pub async fn query_view_rows(
     pool: &PgPool,
     params: &ViewRowsQueryParams<'_>,
+    tz: chrono_tz::Tz,
 ) -> anyhow::Result<QueryResult> {
     let plan = plan_view_query(pool, &params.draft).await?;
     query_projected_rows(
@@ -3702,6 +3710,7 @@ pub async fn query_view_rows(
         params.search,
         params.filters,
         params.exact_filters,
+        tz,
     )
     .await
 }
@@ -3712,6 +3721,7 @@ pub async fn preview_view_shape(
     base_table: &str,
     shape: &ViewDefinitionShape,
     page_size: u32,
+    tz: chrono_tz::Tz,
 ) -> anyhow::Result<QueryResult> {
     if shape.columns.is_empty() {
         return Ok(QueryResult {
@@ -3733,6 +3743,7 @@ pub async fn preview_view_shape(
         None,
         &HashMap::new(),
         &HashMap::new(),
+        tz,
     )
     .await
 }
@@ -3749,6 +3760,7 @@ pub async fn query_view_shape_rows(
     search: Option<&str>,
     filters: &HashMap<String, String>,
     exact_filters: &HashMap<String, String>,
+    tz: chrono_tz::Tz,
 ) -> anyhow::Result<QueryResult> {
     let plan = plan_view_shape_query(pool, base_schema, base_table, shape).await?;
     query_projected_rows(
@@ -3760,6 +3772,7 @@ pub async fn query_view_shape_rows(
         search,
         filters,
         exact_filters,
+        tz,
     )
     .await
 }
@@ -3854,7 +3867,11 @@ pub async fn export_view_rows_stream<'a>(
 }
 
 /// Query paginated rows from a table with optional sort, search, and per-column filters.
-pub async fn query_rows(pool: &PgPool, params: &RowQueryParams<'_>) -> anyhow::Result<QueryResult> {
+pub async fn query_rows(
+    pool: &PgPool,
+    params: &RowQueryParams<'_>,
+    tz: chrono_tz::Tz,
+) -> anyhow::Result<QueryResult> {
     let schema = params.schema;
     let table = params.table;
 
@@ -3906,7 +3923,7 @@ pub async fn query_rows(pool: &PgPool, params: &RowQueryParams<'_>) -> anyhow::R
         .map(|row| {
             let mut map = serde_json::Map::new();
             for col in &columns {
-                let val = pg_value_to_json(row, &col.name, &col.data_type);
+                let val = pg_value_to_json(row, &col.name, &col.data_type, tz);
                 map.insert(col.name.clone(), val);
             }
             serde_json::Value::Object(map)
@@ -3931,6 +3948,7 @@ pub async fn query_single_row(
     schema: &str,
     table: &str,
     exact_filters: &HashMap<String, String>,
+    tz: chrono_tz::Tz,
 ) -> anyhow::Result<(Option<serde_json::Value>, bool)> {
     if !is_valid_identifier(schema) {
         anyhow::bail!("Invalid schema name");
@@ -3960,7 +3978,7 @@ pub async fn query_single_row(
     let first_row = rows.first().map(|row| {
         let mut map = serde_json::Map::new();
         for col in &columns {
-            let val = pg_value_to_json(row, &col.name, &col.data_type);
+            let val = pg_value_to_json(row, &col.name, &col.data_type, tz);
             map.insert(col.name.clone(), val);
         }
         serde_json::Value::Object(map)
@@ -4092,7 +4110,25 @@ fn build_row_select_list(columns: &[ColumnInfo], spatial: &HashMap<String, Strin
 }
 
 /// Convert a PostgreSQL column value to a serde_json::Value.
-fn pg_value_to_json(row: &sqlx::postgres::PgRow, col: &str, data_type: &str) -> serde_json::Value {
+/// Render a timestamptz in the configured display zone as RFC 3339. chrono-tz
+/// computes the offset for the given instant, so a DST change gives the correct
+/// offset per value.
+pub fn format_timestamptz(v: chrono::DateTime<chrono::Utc>, tz: chrono_tz::Tz) -> String {
+    v.with_timezone(&tz).to_rfc3339()
+}
+
+/// Render a timetz using the offset stored with the value. A timetz carries its
+/// own offset by definition, so the display zone does not apply here.
+pub fn format_timetz(time: chrono::NaiveTime, offset: chrono::FixedOffset) -> String {
+    format!("{}{}", time.format("%H:%M:%S"), offset)
+}
+
+fn pg_value_to_json(
+    row: &sqlx::postgres::PgRow,
+    col: &str,
+    data_type: &str,
+    tz: chrono_tz::Tz,
+) -> serde_json::Value {
     use serde_json::Value;
 
     match data_type {
@@ -4146,15 +4182,19 @@ fn pg_value_to_json(row: &sqlx::postgres::PgRow, col: &str, data_type: &str) -> 
             .unwrap_or(Value::Null),
         "timestamp with time zone" => row
             .try_get::<chrono::DateTime<chrono::Utc>, _>(col)
-            .map(|v| Value::String(v.to_rfc3339()))
+            .map(|v| Value::String(format_timestamptz(v, tz)))
             .unwrap_or(Value::Null),
         "date" => row
             .try_get::<chrono::NaiveDate, _>(col)
             .map(|v| Value::String(v.format("%Y-%m-%d").to_string()))
             .unwrap_or(Value::Null),
-        "time without time zone" | "time with time zone" => row
+        "time without time zone" => row
             .try_get::<chrono::NaiveTime, _>(col)
             .map(|v| Value::String(v.format("%H:%M:%S").to_string()))
+            .unwrap_or(Value::Null),
+        "time with time zone" => row
+            .try_get::<sqlx::postgres::types::PgTimeTz, _>(col)
+            .map(|v| Value::String(format_timetz(v.time, v.offset)))
             .unwrap_or(Value::Null),
         "uuid" => row
             .try_get::<uuid::Uuid, _>(col)
@@ -4223,6 +4263,82 @@ fn is_text_type(data_type: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn utc_at(text: &str) -> chrono::DateTime<chrono::Utc> {
+        text.parse::<chrono::DateTime<chrono::Utc>>()
+            .expect("test timestamp parses")
+    }
+
+    #[test]
+    fn timestamptz_follows_dst_in_the_display_zone() {
+        // New York sits at -05:00 before the 2024 spring change and at -04:00 after it.
+        assert_eq!(
+            format_timestamptz(utc_at("2024-03-09T12:00:00Z"), chrono_tz::America::New_York),
+            "2024-03-09T07:00:00-05:00"
+        );
+        assert_eq!(
+            format_timestamptz(utc_at("2024-03-11T12:00:00Z"), chrono_tz::America::New_York),
+            "2024-03-11T08:00:00-04:00"
+        );
+    }
+
+    #[test]
+    fn timestamptz_handles_half_hour_and_southern_zones() {
+        // Adelaide runs +10:30 in the southern summer and +09:30 in the winter.
+        assert_eq!(
+            format_timestamptz(
+                utc_at("2024-01-15T00:00:00Z"),
+                chrono_tz::Australia::Adelaide
+            ),
+            "2024-01-15T10:30:00+10:30"
+        );
+        assert_eq!(
+            format_timestamptz(
+                utc_at("2024-07-15T00:00:00Z"),
+                chrono_tz::Australia::Adelaide
+            ),
+            "2024-07-15T09:30:00+09:30"
+        );
+    }
+
+    #[test]
+    fn timestamptz_in_utc_keeps_the_instant() {
+        assert_eq!(
+            format_timestamptz(utc_at("2024-01-15T14:30:00Z"), chrono_tz::UTC),
+            "2024-01-15T14:30:00+00:00"
+        );
+    }
+
+    #[test]
+    fn timestamptz_in_singapore_shifts_the_wall_clock() {
+        assert_eq!(
+            format_timestamptz(utc_at("2024-01-15T14:30:00Z"), chrono_tz::Asia::Singapore),
+            "2024-01-15T22:30:00+08:00"
+        );
+    }
+
+    #[test]
+    fn timetz_uses_the_offset_stored_with_the_value() {
+        let time = |h, m, sec| chrono::NaiveTime::from_hms_opt(h, m, sec).unwrap();
+        assert_eq!(
+            format_timetz(
+                time(14, 30, 0),
+                chrono::FixedOffset::east_opt(8 * 3600).unwrap()
+            ),
+            "14:30:00+08:00"
+        );
+        assert_eq!(
+            format_timetz(
+                time(6, 15, 0),
+                chrono::FixedOffset::west_opt(5 * 3600).unwrap()
+            ),
+            "06:15:00-05:00"
+        );
+        assert_eq!(
+            format_timetz(time(0, 0, 0), chrono::FixedOffset::east_opt(0).unwrap()),
+            "00:00:00+00:00"
+        );
+    }
 
     fn expression_info(data_type: &str, display_type: &str) -> ExpressionInfo {
         ExpressionInfo {

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,9 @@ use crate::db::DatabasePool;
 pub struct AppState {
     pub db: DatabasePool,
     pub config: AppConfig,
+    /// Display time zone, parsed once at startup. Handlers pass it into the
+    /// database layer so every timestamp renders in the same zone.
+    pub display_tz: chrono_tz::Tz,
 }
 
 #[tokio::main]
@@ -38,9 +41,15 @@ async fn main() -> anyhow::Result<()> {
             let secrets = SecretsConfig::load_from_cwd();
             let ssh_pair = config.ssh.as_ref().map(|s| (s, &secrets));
             tracing::info!("Connecting to database...");
-            let db = DatabasePool::connect(&config.database, ssh_pair).await?;
+            let db =
+                DatabasePool::connect(&config.database, ssh_pair, &config.display.timezone).await?;
             tracing::info!("Connected to database");
-            initial_mode(Some(AppState { db, config }))
+            let display_tz = config.display.parsed_timezone();
+            initial_mode(Some(AppState {
+                db,
+                config,
+                display_tz,
+            }))
         }
         Err(ConfigLoadError::NotFound) => {
             tracing::info!("No config file found — starting in setup mode");


### PR DESCRIPTION
Closes #134.

## Problem

Three zones disagreed and nothing made them agree: the Postgres session zone (never set), the UTC we serialized `timestamptz` into, and the browser zone that rendered it. The grid, its tooltip, the CSV export, and view-builder date math each picked a different one.

## Fix

One IANA display timezone, resolved once at startup and applied in all four layers.

1. `[display] timezone = "Asia/Singapore"` in `seeki.toml` (default `UTC`). Config load rejects an invalid name. It does not fall back silently.
2. Every pooled connection pins the zone via `after_connect` with `set_config('TimeZone', $1, false)`. The zone is a bind parameter, never interpolated. This fixes view-builder `DATE_TRUNC` / `EXTRACT` / `TO_CHAR` / `AGE` bucketing and temporal filter casts together.
3. `timestamptz` serializes in that zone with its real per-instant offset, in both the grid JSON and the CSV export, so the two agree and DST lands correctly.
4. `GET /api/config/display` carries the zone. The frontend formats with `Intl`'s `timeZone` option instead of the viewer's local zone, and renders naive `timestamp` values from their literal parts so they never shift per viewer.
5. `timetz` decodes via `sqlx::postgres::types::PgTimeTz` and renders `HH:MM:SS+/-HH:MM` instead of dropping the offset.

The deliberate date-only `T00:00:00` handling in `data-grid.ts` is preserved.

## Behaviour change to flag in the release note

Saved views that bucket by day or week, or use `EXTRACT` or `AGE`, previously evaluated in the server's zone. They now evaluate in the configured display zone. Existing counts can move. This is the correction landing, not a regression.

## Test plan

- [x] `cargo test`: 291 passed, includes new DST tests (America/New_York, Australia/Adelaide half-hour zone), timetz rendering, config validation, CSV/grid parity
- [x] `vitest`: 265 passed, also green under `TZ=America/New_York` and `TZ=Pacific/Kiritimati`
- [x] `cargo clippy --all-targets`: 0 warnings. `cargo fmt --check` clean. `npm run check` 0 errors
- [ ] Manual: run against a real database with `timezone = "Asia/Singapore"` and confirm grid, tooltip, CSV, and a counts-per-day view agree